### PR TITLE
Added include_staff parameter to handgrading results endpoint.

### DIFF
--- a/autograder/handgrading/models.py
+++ b/autograder/handgrading/models.py
@@ -193,7 +193,7 @@ class Annotation(AutograderModel):
 
 class HandgradingResult(AutograderModel):
     """
-    Contains general information about a group's handgrading result
+    Contains general information about a group's handgrading result.
     Represents the handgrading result of a group's best submission.
     """
     group = models.OneToOneField(


### PR DESCRIPTION
Uptaded handgrading results API docs to specify that the value 'handgrading_result' can be null.

Fixes #378 
Fixes #379 