### PR TITLE
Adds alternate email API

### DIFF
--- a/autograder/rest_api/views/oauth2callback.py
+++ b/autograder/rest_api/views/oauth2callback.py
@@ -38,11 +38,11 @@ def oauth2_callback(request):
 
         try:
             email = utils.find_if(
-                    user_info['emailAddresses'], lambda data: data['metadata']['primary'])
+                user_info['emailAddresses'], lambda data: data['metadata']['primary'])
             email = email['value']
         except KeyError:
-            print ('WARNING: emailAddress not found. Using alternate API')
-            em_url = ( 'https://www.googleapis.com/userinfo/v2/me?fields=email' )
+            print('WARNING: emailAddress not found. Using alternate API')
+            em_url = ('https://www.googleapis.com/userinfo/v2/me?fields=email')
             em_response, em_content = http.request(em_url, 'GET')
             em_user_info = json.loads(em_content)
             email = em_user_info['email']

--- a/autograder/rest_api/views/oauth2callback.py
+++ b/autograder/rest_api/views/oauth2callback.py
@@ -36,12 +36,19 @@ def oauth2_callback(request):
         response, content = http.request(url, 'GET')
         user_info = json.loads(content)
 
-        email = utils.find_if(
-            user_info['emailAddresses'], lambda data: data['metadata']['primary'])
+        try:
+            email = utils.find_if(
+                    user_info['emailAddresses'], lambda data: data['metadata']['primary'])
+            email = email['value']
+        except KeyError:
+            print ('WARNING: emailAddress not found. Using alternate API')
+            em_url = ( 'https://www.googleapis.com/userinfo/v2/me?fields=email' )
+            em_response, em_content = http.request(em_url, 'GET')
+            em_user_info = json.loads(em_content)
+            email = em_user_info['email']
+
         if email is None:
             raise RuntimeError('Primary email not found in user info')
-
-        email = email['value']
 
         # It is possible for 'names' to be absent in some rare cases.
         if 'names' not in user_info:


### PR DESCRIPTION
The current API doesn't seem to provide email address for @iu.edu accounts.  This patch uses an alternate API to determine the email in the event the primary API doesn't provide that information.  