### PR TITLE
Attempt at fixing project queue registration reliability

### DIFF
--- a/autograder/grading_tasks/tasks/queueing.py
+++ b/autograder/grading_tasks/tasks/queueing.py
@@ -23,7 +23,7 @@ def queue_submissions():
         print('queued {} submissions'.format(to_queue))
 
 
-@celery.shared_task(acks_late=True, autoretry_for=(Exception,))
+@celery.shared_task(acks_late=True, autoretry_for=(Exception,), default_retry_delay=5)
 def register_project_queues(worker_names=None, project_pks=None):
     from autograder.celery import app
 
@@ -31,14 +31,14 @@ def register_project_queues(worker_names=None, project_pks=None):
         worker_names = [worker_name for worker_name in app.control.inspect().active()
                         if worker_name.startswith(settings.SUBMISSION_WORKER_PREFIX)]
 
-    print('worker names', worker_names)
+    print('worker names', worker_names, flush=True)
     if not worker_names:
         return
 
     if not project_pks:
         project_pks = [project.pk for project in ag_models.Project.objects.all()]
 
-    print('project pks:', project_pks)
+    print('project pks:', project_pks, flush=True)
     for pk in project_pks:
         res = app.control.add_consumer('project{}'.format(pk), destination=worker_names)
         print(res)

--- a/autograder/settings/celery_settings.py
+++ b/autograder/settings/celery_settings.py
@@ -7,6 +7,7 @@ import os
 BROKER_URL = os.environ.get('AG_CELERY_BROKER_URL', 'amqp://guest@localhost:5672//')
 
 CELERYD_PREFETCH_MULTIPLIER = 1
+# Set this using the -c flag for the worker
 CELERYD_CONCURRENCY = 1
 
 CELERY_TASK_SERIALIZER = 'json'
@@ -19,11 +20,7 @@ CELERY_RESULT_BACKEND = os.environ.get('AG_CELERY_RESULTS_BACKEND_URL',
                                        'redis://localhost:6379/0')
 CELERY_RESULT_PERSISTENT = True
 
-# Probably want to set some high max for this?
-# CELERYD_TASK_TIME_LIMIT =
-
-# Set this using the -c flag for the worker
-# CELERYD_CONCURRENCY
+BROKER_POOL_LIMIT = None
 
 CELERYBEAT_SCHEDULE = {
     'queue-submissions': {


### PR DESCRIPTION
Set BROKER_POOL_LIMIT to None and reduced register_project_queues retry delay.