### PR TITLE
424 redis delete pattern performance

### DIFF
--- a/autograder/core/models/course.py
+++ b/autograder/core/models/course.py
@@ -224,5 +224,5 @@ class LateDaysRemaining(AutograderModel):
 
 
 def clear_cached_user_roles(course_pk: int) -> None:
-    keys = cache.scan_iter(f'course_{course_pk}_user_*', 5000)
+    keys = cache.client.iter_keys(f'course_{course_pk}_user_*', itersize=5000)
     cache.delete_many(list(keys))

--- a/autograder/core/models/course.py
+++ b/autograder/core/models/course.py
@@ -224,4 +224,5 @@ class LateDaysRemaining(AutograderModel):
 
 
 def clear_cached_user_roles(course_pk: int) -> None:
-    cache.delete_pattern(f'course_{course_pk}_user_*')
+    keys = cache.scan_iter(f'course_{course_pk}_user_*', 5000)
+    cache.delete_many(list(keys))

--- a/autograder/rest_api/views/project_views/project_views.py
+++ b/autograder/rest_api/views/project_views/project_views.py
@@ -235,7 +235,8 @@ class ProjectDetailViewSet(mixins.RetrieveModelMixin,
         with transaction.atomic():
             project = self.get_object()
 
-        keys = cache.scan_iter('project_{}_submission_normal_results_*'.format(project.pk), 5000)
+        keys = cache.client.iter_keys('project_{}_submission_normal_results_*'.format(project.pk),
+                                      itersize=5000)
         cache.delete_many(list(keys))
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/autograder/rest_api/views/project_views/project_views.py
+++ b/autograder/rest_api/views/project_views/project_views.py
@@ -235,7 +235,8 @@ class ProjectDetailViewSet(mixins.RetrieveModelMixin,
         with transaction.atomic():
             project = self.get_object()
 
-        cache.delete_pattern('project_{}_submission_normal_results_*'.format(project.pk))
+        keys = cache.scan_iter('project_{}_submission_normal_results_*'.format(project.pk), 5000)
+        cache.delete_many(list(keys))
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 
 


### PR DESCRIPTION
Replaced calls to cache.delete_pattern() with iter_keys and delete_many.
The current implementation of delete_pattern seems to make a call to delete for every key it finds, which is inefficient.

Fixes #424

Note that this makes a similar change for clearing cached submission results.