### PR TITLE
Fix rerun submission stalling bug

### DIFF
--- a/autograder/settings/base.py
+++ b/autograder/settings/base.py
@@ -198,4 +198,29 @@ INSTALLED_APPS += [
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '[contactor] %(levelname)s %(asctime)s %(message)s'
+        },
+    },
+    'handlers': {
+        # Send all messages to console
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        # This is the "catch all" logger
+        '': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        },
+    }
+}
+
 from autograder.settings.celery_settings import *  # noqa

--- a/autograder/settings/production.py
+++ b/autograder/settings/production.py
@@ -7,34 +7,3 @@ DEBUG = False
 AG_TEST_MAX_RETRIES = 5
 AG_TEST_MIN_RETRY_DELAY = 7
 AG_TEST_MAX_RETRY_DELAY = 15
-
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        }
-    },
-    'formatters': {
-        'verbose': {
-            'format': '[contactor] %(levelname)s %(asctime)s %(message)s'
-        },
-    },
-    'handlers': {
-        # Send all messages to console
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-        },
-    },
-    'loggers': {
-        # This is the "catch all" logger
-        '': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-    }
-}


### PR DESCRIPTION
Removed connection kwarg from apply_async and added app kwarg to chord creation when creating a rerun submission task.

For chords, celery's apply_async apparently ignores the connection argument and instead requires
the app argument to the chord itself. See https://docs.celeryproject.org/en/latest/reference/celery.html#celery.chord for
some of these details.

Also moved logging configuration into base settings.

Fixes #469 