### PR TITLE
List submissions with results endpoint

### DIFF
--- a/autograder/core/tests/test_models/test_student_test_suite/test_student_test_suite_result.py
+++ b/autograder/core/tests/test_models/test_student_test_suite/test_student_test_suite_result.py
@@ -2,6 +2,7 @@ import decimal
 import os
 
 import autograder.core.models as ag_models
+from autograder.core.submission_feedback import StudentTestSuitePreLoader
 from autograder.utils.testing import UnitTestBase
 import autograder.utils.testing.model_obj_builders as obj_build
 import autograder.core.utils as core_ut
@@ -129,21 +130,30 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
             f.write(self.grade_buggy_impls_stderr)
 
     def test_feedback_calculator_factory_method(self):
-        # check against the actual objects (their pks)
         self.assertEqual(
-            self.student_suite.normal_fdbk_config,
-            self.result.get_fdbk(ag_models.FeedbackCategory.normal).fdbk_conf)
+            self.student_suite.normal_fdbk_config.to_dict(),
+            self.result.get_fdbk(
+                ag_models.FeedbackCategory.normal,
+                StudentTestSuitePreLoader(self.project)).fdbk_settings)
         self.assertEqual(
-            self.student_suite.ultimate_submission_fdbk_config,
-            self.result.get_fdbk(ag_models.FeedbackCategory.ultimate_submission).fdbk_conf)
+            self.student_suite.ultimate_submission_fdbk_config.to_dict(),
+            self.result.get_fdbk(
+                ag_models.FeedbackCategory.ultimate_submission,
+                StudentTestSuitePreLoader(self.project)).fdbk_settings)
         self.assertEqual(
-            self.student_suite.past_limit_submission_fdbk_config,
-            self.result.get_fdbk(ag_models.FeedbackCategory.past_limit_submission).fdbk_conf)
+            self.student_suite.past_limit_submission_fdbk_config.to_dict(),
+            self.result.get_fdbk(
+                ag_models.FeedbackCategory.past_limit_submission,
+                StudentTestSuitePreLoader(self.project)).fdbk_settings)
         self.assertEqual(
-            self.student_suite.staff_viewer_fdbk_config,
-            self.result.get_fdbk(ag_models.FeedbackCategory.staff_viewer).fdbk_conf)
+            self.student_suite.staff_viewer_fdbk_config.to_dict(),
+            self.result.get_fdbk(
+                ag_models.FeedbackCategory.staff_viewer,
+                StudentTestSuitePreLoader(self.project)).fdbk_settings)
 
-        max_fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max).fdbk_conf
+        max_fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project)).fdbk_conf
         self.assertTrue(max_fdbk.visible)
         self.assertTrue(max_fdbk.show_setup_return_code)
         self.assertTrue(max_fdbk.show_setup_stdout)
@@ -160,11 +170,15 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
     def test_discarded_tests(self):
         discarded_tests = ['spam', 'egg']
         self.result.discarded_tests = discarded_tests
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertSequenceEqual(discarded_tests, fdbk.discarded_tests)
 
     def test_points_values_catch_all_bugs(self):
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.points_awarded, fdbk.total_points)
         self.assertEqual(self.points_possible, fdbk.total_points_possible)
 
@@ -174,7 +188,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.result.bugs_exposed = self.bug_names[:num_bugs_exposed]
         self.result.save()
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(num_bugs_exposed * self.points_per_exposed_bug, fdbk.total_points)
         self.assertEqual(self.points_possible, fdbk.total_points_possible)
 
@@ -182,7 +198,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.result.bugs_exposed = []
         self.result.save()
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(0, fdbk.total_points)
         self.assertEqual(self.points_possible, fdbk.total_points_possible)
 
@@ -191,7 +209,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.assertGreater(max_points, 0)
         self.student_suite.validate_and_update(max_points=max_points)
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(max_points, fdbk.total_points)
         self.assertEqual(max_points, fdbk.total_points_possible)
 
@@ -203,7 +223,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.result.bugs_exposed = []
         self.result.save()
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(0, fdbk.total_points)
         self.assertEqual(max_points, fdbk.total_points_possible)
 
@@ -211,11 +233,15 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         name = 'wuuuuuuuluigio42'
         self.student_suite.validate_and_update(setup_command={'name': name})
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(name, fdbk.setup_command_name)
 
     def test_has_setup_command(self):
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertTrue(fdbk.has_setup_command)
 
     def test_show_and_hide_setup_return_code(self):
@@ -225,7 +251,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         return_code = 31
         self.result.setup_result.return_code = return_code
         self.setup_result.save()
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(return_code, fdbk.setup_return_code)
         self.assertIsNotNone(fdbk.setup_timed_out)
         self.assertFalse(fdbk.setup_timed_out)
@@ -233,7 +261,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_setup_return_code': False})
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.setup_return_code)
         self.assertIsNone(fdbk.setup_timed_out)
 
@@ -248,7 +278,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.result.setup_result.return_code = None
         self.result.setup_result.timed_out = True
         self.setup_result.save()
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.setup_return_code)
         self.assertIsNotNone(fdbk.setup_timed_out)
         self.assertTrue(fdbk.setup_timed_out)
@@ -258,7 +290,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_setup_return_code': True})
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNotNone(self.result.setup_result.return_code)
         self.assertEqual(self.result.setup_result.return_code, fdbk.setup_return_code)
 
@@ -272,29 +306,39 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
 
         self.result.setup_result = None
         self.result.save()
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.setup_return_code)
         self.assertIsNone(fdbk.setup_timed_out)
 
     def test_show_and_hide_setup_stdout(self):
         self.student_suite.validate_and_update(normal_fdbk_config={'show_setup_stdout': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.setup_stdout, fdbk.setup_stdout.read().decode())
         self.assertEqual(len(self.setup_stdout), fdbk.get_setup_stdout_size())
 
         self.student_suite.validate_and_update(normal_fdbk_config={'show_setup_stdout': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.setup_stdout)
         self.assertIsNone(fdbk.get_setup_stdout_size())
 
     def test_show_and_hide_setup_stderr(self):
         self.student_suite.validate_and_update(normal_fdbk_config={'show_setup_stderr': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.setup_stderr, fdbk.setup_stderr.read().decode())
         self.assertEqual(len(self.setup_stderr), fdbk.get_setup_stderr_size())
 
         self.student_suite.validate_and_update(normal_fdbk_config={'show_setup_stderr': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.setup_stderr)
         self.assertIsNone(fdbk.get_setup_stderr_size())
 
@@ -302,7 +346,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.student_suite.validate_and_update(use_setup_command=False)
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_setup_stdout': True, 'show_setup_stderr': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.setup_stdout, fdbk.setup_stdout.read().decode())
         self.assertEqual(len(self.setup_stdout), fdbk.get_setup_stdout_size())
         self.assertEqual(self.setup_stderr, fdbk.setup_stderr.read().decode())
@@ -315,7 +361,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
 
         self.result.setup_result = None
         self.result.save()
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.setup_stdout)
         self.assertIsNone(fdbk.get_setup_stderr_size())
         self.assertIsNone(fdbk.setup_stderr)
@@ -325,7 +373,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_get_test_names_return_code': True})
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.get_test_names_return_code, fdbk.get_student_test_names_return_code)
         self.assertIsNotNone(fdbk.get_student_test_names_timed_out)
         self.assertFalse(fdbk.get_student_test_names_timed_out)
@@ -333,14 +383,18 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_get_test_names_return_code': False})
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.get_student_test_names_return_code)
         self.assertIsNone(fdbk.get_student_test_names_timed_out)
 
     def test_show_and_hide_get_test_names_stdout(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_get_test_names_stdout': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.get_test_names_stdout,
                          fdbk.get_student_test_names_stdout.read().decode())
         self.assertEqual(len(self.get_test_names_stdout),
@@ -348,14 +402,18 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_get_test_names_stdout': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.get_student_test_names_stdout)
         self.assertIsNone(fdbk.get_student_test_names_stdout_size())
 
     def test_show_and_hide_get_test_names_stderr(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_get_test_names_stderr': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.get_test_names_stderr,
                          fdbk.get_student_test_names_stderr.read().decode())
         self.assertEqual(len(self.get_test_names_stderr),
@@ -363,40 +421,52 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_get_test_names_stderr': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.get_student_test_names_stderr)
         self.assertIsNone(fdbk.get_student_test_names_stderr_size())
 
     def test_show_and_hide_validity_check_stdout(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_validity_check_stdout': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.validity_check_stdout, fdbk.validity_check_stdout.read().decode())
         self.assertEqual(len(self.validity_check_stdout), fdbk.get_validity_check_stdout_size())
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_validity_check_stdout': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.validity_check_stdout)
         self.assertIsNone(fdbk.get_validity_check_stdout_size())
 
     def test_show_and_hide_validity_check_stderr(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_validity_check_stderr': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.validity_check_stderr, fdbk.validity_check_stderr.read().decode())
         self.assertEqual(len(self.validity_check_stderr), fdbk.get_validity_check_stderr_size())
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_validity_check_stderr': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.validity_check_stderr)
         self.assertIsNone(fdbk.get_validity_check_stdout_size())
 
     def test_show_and_hide_grade_impl_stdout(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_grade_buggy_impls_stdout': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.grade_buggy_impls_stdout,
                          fdbk.grade_buggy_impls_stdout.read().decode())
         self.assertEqual(len(self.grade_buggy_impls_stdout),
@@ -404,14 +474,18 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_grade_buggy_impls_stdout': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.grade_buggy_impls_stdout)
         self.assertIsNone(fdbk.get_grade_buggy_impls_stdout_size())
 
     def test_show_and_hide_grade_impl_stderr(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_grade_buggy_impls_stderr': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(self.grade_buggy_impls_stderr,
                          fdbk.grade_buggy_impls_stderr.read().decode())
         self.assertEqual(len(self.grade_buggy_impls_stderr),
@@ -419,21 +493,27 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_grade_buggy_impls_stderr': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.grade_buggy_impls_stderr)
         self.assertIsNone(fdbk.get_grade_buggy_impls_stderr_size())
 
     def test_show_and_hide_invalid_and_timed_out_test_names(self):
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_invalid_test_names': True})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertSequenceEqual(self.student_tests, fdbk.student_tests)
         self.assertSequenceEqual(self.invalid_tests, fdbk.invalid_tests)
         self.assertSequenceEqual(self.timeout_tests, fdbk.timed_out_tests)
 
         self.student_suite.validate_and_update(
             normal_fdbk_config={'show_invalid_test_names': False})
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertSequenceEqual(self.student_tests, fdbk.student_tests)
         self.assertIsNone(fdbk.invalid_tests)
         self.assertIsNone(fdbk.timed_out_tests)
@@ -444,7 +524,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
             self.student_suite.validate_and_update(
                 normal_fdbk_config={'bugs_exposed_fdbk_level': fdbk_level})
 
-            fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+            fdbk = self.result.get_fdbk(
+                ag_models.FeedbackCategory.normal,
+                StudentTestSuitePreLoader(self.project))
 
             self.assertEqual(0, fdbk.total_points)
             self.assertEqual(0, fdbk.total_points_possible)
@@ -457,7 +539,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
             }
         )
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.num_bugs_exposed)
         self.assertIsNone(fdbk.bugs_exposed)
         self.assertEqual(0, fdbk.total_points)
@@ -471,7 +555,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
             }
         )
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(len(self.bugs_exposed), fdbk.num_bugs_exposed)
         self.assertIsNone(fdbk.bugs_exposed)
         self.assertEqual(self.points_awarded, fdbk.total_points)
@@ -485,7 +571,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
             }
         )
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.normal)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(len(self.bugs_exposed), fdbk.num_bugs_exposed)
         self.assertSequenceEqual(self.bugs_exposed, fdbk.bugs_exposed)
         self.assertEqual(self.points_awarded, fdbk.total_points)
@@ -494,11 +582,15 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
     def test_max_points_upper_score_limit(self):
         max_points = (
             len(self.bug_names) * self.points_per_exposed_bug - self.points_per_exposed_bug)
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertGreater(fdbk.total_points_possible, max_points)
 
         self.student_suite.validate_and_update(max_points=max_points)
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         self.assertEqual(max_points, fdbk.total_points)
         self.assertEqual(max_points, fdbk.total_points_possible)
 
@@ -507,7 +599,9 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
         self.result.bugs_exposed = self.bug_names[:3]
         self.result.save()
 
-        fdbk = self.result.get_fdbk(ag_models.FeedbackCategory.max)
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project))
         # Keep these magic numbers up to date with setUp.
         # Do NOT compute the expected result with multiplication.
         # These numbers have been specifically chosen to test
@@ -541,5 +635,7 @@ class StudentTestSuiteResultFeedbackTestCase(UnitTestBase):
             'total_points_possible',
         ]
 
-        serialized = self.result.get_fdbk(ag_models.FeedbackCategory.max).to_dict()
+        serialized = self.result.get_fdbk(
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project)).to_dict()
         self.assertCountEqual(expected_fields, serialized.keys())

--- a/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
@@ -5,8 +5,9 @@ from autograder.core.models import get_submissions_with_results_queryset
 from autograder.core.submission_feedback import update_denormalized_ag_test_results
 from autograder.core.tests.test_submission_feedback.fdbk_getter_shortcuts import (
     get_suite_fdbk, get_submission_fdbk)
-from autograder.utils.testing import UnitTestBase
 import autograder.core.models as ag_models
+from autograder.core.submission_feedback import StudentTestSuitePreLoader
+from autograder.utils.testing import UnitTestBase
 import autograder.utils.testing.model_obj_builders as obj_build
 
 
@@ -93,7 +94,9 @@ class SubmissionFeedbackTestCase(UnitTestBase):
 
         self.assertEqual(
             self.total_points_per_student_suite,
-            self.student_suite_result1.get_fdbk(ag_models.FeedbackCategory.max).total_points)
+            self.student_suite_result1.get_fdbk(
+                ag_models.FeedbackCategory.max,
+                StudentTestSuitePreLoader(self.project)).total_points)
 
         print(self.total_points)
         self.assertNotEqual(0, self.total_points_per_ag_suite)
@@ -285,8 +288,12 @@ class SubmissionFeedbackTestCase(UnitTestBase):
         self.assertSequenceEqual([self.student_suite_result2, self.student_suite_result1],
                                  fdbk.student_test_suite_results)
         self.assertSequenceEqual(
-            [self.student_suite_result2.get_fdbk(ag_models.FeedbackCategory.max).to_dict(),
-             self.student_suite_result1.get_fdbk(ag_models.FeedbackCategory.max).to_dict()],
+            [self.student_suite_result2.get_fdbk(
+                ag_models.FeedbackCategory.max,
+                StudentTestSuitePreLoader(self.project)).to_dict(),
+             self.student_suite_result1.get_fdbk(
+                 ag_models.FeedbackCategory.max,
+                 StudentTestSuitePreLoader(self.project)).to_dict()],
             fdbk.to_dict()['student_test_suite_results'])
 
     def test_some_ag_and_student_test_suites_not_visible(self):
@@ -311,7 +318,8 @@ class SubmissionFeedbackTestCase(UnitTestBase):
         self.assertSequenceEqual([self.student_suite_result1], fdbk.student_test_suite_results)
         self.assertSequenceEqual(
             [self.student_suite_result1.get_fdbk(
-                ag_models.FeedbackCategory.ultimate_submission).to_dict()],
+                ag_models.FeedbackCategory.ultimate_submission,
+                StudentTestSuitePreLoader(self.project)).to_dict()],
             fdbk.to_dict()['student_test_suite_results'])
 
     def test_fdbk_to_dict(self):
@@ -324,8 +332,12 @@ class SubmissionFeedbackTestCase(UnitTestBase):
                 get_suite_fdbk(self.ag_suite_result2, ag_models.FeedbackCategory.max).to_dict()
             ],
             'student_test_suite_results': [
-                self.student_suite_result1.get_fdbk(ag_models.FeedbackCategory.max).to_dict(),
-                self.student_suite_result2.get_fdbk(ag_models.FeedbackCategory.max).to_dict(),
+                self.student_suite_result1.get_fdbk(
+                    ag_models.FeedbackCategory.max,
+                    StudentTestSuitePreLoader(self.project)).to_dict(),
+                self.student_suite_result2.get_fdbk(
+                    ag_models.FeedbackCategory.max,
+                    StudentTestSuitePreLoader(self.project)).to_dict(),
             ]
         }
 

--- a/autograder/rest_api/serialize_ultimate_submission_results.py
+++ b/autograder/rest_api/serialize_ultimate_submission_results.py
@@ -50,7 +50,7 @@ def serialize_ultimate_submission_results(ultimate_submissions: Iterable[Submiss
         if group.extended_due_date is not None and group.extended_due_date > timezone.now():
             submission_data = None
         else:
-            submission_data = _get_submission_data_with_results(submission_fdbk, full_results,
+            submission_data = get_submission_data_with_results(submission_fdbk, full_results,
                                                                 include_handgrading)
 
         group_data = group.to_dict()
@@ -65,7 +65,7 @@ def serialize_ultimate_submission_results(ultimate_submissions: Iterable[Submiss
                 user_ultimate_submission = get_ultimate_submission(
                     group, group.members.get(username=username))
                 # NOTE: Do NOT overwrite submission_data
-                user_submission_data = _get_submission_data_with_results(
+                user_submission_data = get_submission_data_with_results(
                     SubmissionResultFeedback(
                         user_ultimate_submission, ag_models.FeedbackCategory.max,
                         submission_fdbk.ag_test_preloader),
@@ -81,9 +81,9 @@ def serialize_ultimate_submission_results(ultimate_submissions: Iterable[Submiss
     return results
 
 
-def _get_submission_data_with_results(submission_fdbk: SubmissionResultFeedback,
-                                      full_results: bool,
-                                      include_handgrading: bool = False):
+def get_submission_data_with_results(submission_fdbk: SubmissionResultFeedback,
+                                     full_results: bool,
+                                     include_handgrading: bool = False):
     submission_data = submission_fdbk.submission.to_dict()
 
     if not full_results:

--- a/autograder/rest_api/serialize_ultimate_submission_results.py
+++ b/autograder/rest_api/serialize_ultimate_submission_results.py
@@ -50,8 +50,8 @@ def serialize_ultimate_submission_results(ultimate_submissions: Iterable[Submiss
         if group.extended_due_date is not None and group.extended_due_date > timezone.now():
             submission_data = None
         else:
-            submission_data = get_submission_data_with_results(submission_fdbk, full_results,
-                                                                include_handgrading)
+            submission_data = get_submission_data_with_results(
+                submission_fdbk, full_results, include_handgrading)
 
         group_data = group.to_dict()
 
@@ -67,8 +67,11 @@ def serialize_ultimate_submission_results(ultimate_submissions: Iterable[Submiss
                 # NOTE: Do NOT overwrite submission_data
                 user_submission_data = get_submission_data_with_results(
                     SubmissionResultFeedback(
-                        user_ultimate_submission, ag_models.FeedbackCategory.max,
-                        submission_fdbk.ag_test_preloader),
+                        user_ultimate_submission,
+                        ag_models.FeedbackCategory.max,
+                        submission_fdbk.ag_test_preloader,
+                        submission_fdbk.student_test_suite_preloader
+                    ),
                     full_results,
                     include_handgrading
                 )

--- a/autograder/rest_api/tasks/project_downloads.py
+++ b/autograder/rest_api/tasks/project_downloads.py
@@ -12,7 +12,8 @@ import autograder.core.models as ag_models
 from autograder.core.models.get_ultimate_submissions import get_ultimate_submissions
 import autograder.core.utils as core_ut
 from autograder import utils
-from autograder.core.submission_feedback import SubmissionResultFeedback, AGTestPreLoader
+from autograder.core.submission_feedback import (
+    SubmissionResultFeedback, AGTestPreLoader, StudentTestSuitePreLoader)
 from autograder.rest_api.views.submission_views.all_ultimate_submission_results_view import (
     serialize_ultimate_submission_results)
 
@@ -27,9 +28,14 @@ def _get_all_submissions(
         project: ag_models.Project,
         groups: Sequence[ag_models.Group]) -> Tuple[List[SubmissionResultFeedback], int]:
     ag_test_loader = AGTestPreLoader(project)
+    student_test_suite_loader = StudentTestSuitePreLoader(project)
     submissions = [
-        SubmissionResultFeedback(submission, ag_models.FeedbackCategory.max,
-                                 ag_test_loader)
+        SubmissionResultFeedback(
+            submission,
+            ag_models.FeedbackCategory.max,
+            ag_test_loader,
+            student_test_suite_loader
+        )
         for submission in ag_models.Submission.objects.filter(group__in=groups)
     ]
     return submissions, len(submissions)
@@ -53,8 +59,14 @@ def all_submission_scores_task(project_pk, task_pk, include_staff, *args, **kwar
             )
         )
         ag_test_loader = AGTestPreLoader(project)
+        student_test_suite_loader = StudentTestSuitePreLoader(project)
         fdbks = [
-            SubmissionResultFeedback(submission, ag_models.FeedbackCategory.max, ag_test_loader)
+            SubmissionResultFeedback(
+                submission,
+                ag_models.FeedbackCategory.max,
+                ag_test_loader,
+                student_test_suite_loader
+            )
             for submission in submissions
         ]
         return fdbks, len(submissions)

--- a/autograder/rest_api/tasks/project_downloads.py
+++ b/autograder/rest_api/tasks/project_downloads.py
@@ -225,7 +225,8 @@ def _make_scores_csv(task: ag_models.DownloadTask,
                     row[ag_test_total_header] = case_fdbk.total_points
 
             for student_suite_result in fdbk.student_test_suite_results:
-                suite_fdbk = student_suite_result.get_fdbk(ag_models.FeedbackCategory.max)
+                suite_fdbk = student_suite_result.get_fdbk(
+                    ag_models.FeedbackCategory.max, fdbk.student_test_suite_preloader)
 
                 student_suite_total_header = student_suite_total_tmpl.format(
                     suite_fdbk.student_test_suite_name)

--- a/autograder/rest_api/tests/test_tasks/test_project_downloads.py
+++ b/autograder/rest_api/tests/test_tasks/test_project_downloads.py
@@ -21,6 +21,7 @@ from autograder.core.submission_feedback import (
     update_denormalized_ag_test_results, SubmissionResultFeedback, AGTestPreLoader)
 from autograder.core.tests.test_submission_feedback.fdbk_getter_shortcuts import (
     get_submission_fdbk)
+from autograder.core.submission_feedback import StudentTestSuitePreLoader
 from autograder.utils.testing import UnitTestBase
 
 
@@ -898,7 +899,8 @@ class DownloadAllSubmissionGradesTestCase(UnitTestBase):
                     values.append(str(case_fdbk.total_points))
 
             for suite_result in fdbk.student_test_suite_results:
-                suite_fdbk = suite_result.get_fdbk(ag_models.FeedbackCategory.max)
+                suite_fdbk = suite_result.get_fdbk(
+                    ag_models.FeedbackCategory.max, StudentTestSuitePreLoader(self.project))
                 values += [str(suite_fdbk.total_points), str(suite_fdbk.total_points_possible)]
 
             self.assertEqual(len(expected_headers), len(values))

--- a/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_student_test_suite_feedback.py
+++ b/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_student_test_suite_feedback.py
@@ -4,8 +4,8 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 import autograder.core.models as ag_models
+from autograder.core.submission_feedback import StudentTestSuitePreLoader
 import autograder.utils.testing.model_obj_builders as obj_build
-
 from autograder.utils.testing import UnitTestBase
 
 
@@ -130,7 +130,11 @@ class StudentTestSuiteResultsTestCase(UnitTestBase):
 
         response = self.client.get(url)
         expected_content = [
-            self.student_suite_result.get_fdbk(ag_models.FeedbackCategory.max).to_dict()]
+            self.student_suite_result.get_fdbk(
+                ag_models.FeedbackCategory.max,
+                StudentTestSuitePreLoader(self.project)
+            ).to_dict()
+        ]
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertSequenceEqual(expected_content, response.data['student_test_suite_results'])
 
@@ -218,9 +222,13 @@ class StudentTestSuiteResultsTestCase(UnitTestBase):
     def test_get_output_suite_hidden(self):
         self.maxDiff = None
         max_fdbk_settings = self.student_suite_result.get_fdbk(
-            ag_models.FeedbackCategory.max).fdbk_settings
+            ag_models.FeedbackCategory.max,
+            StudentTestSuitePreLoader(self.project)
+        ).fdbk_settings
         staff_viewer_fdbk_settings = self.student_suite_result.get_fdbk(
-            ag_models.FeedbackCategory.staff_viewer).fdbk_settings
+            ag_models.FeedbackCategory.staff_viewer,
+            StudentTestSuitePreLoader(self.project)
+        ).fdbk_settings
         self.assertEqual(max_fdbk_settings, staff_viewer_fdbk_settings)
 
         self.student_suite.validate_and_update(staff_viewer_fdbk_config={

--- a/autograder/rest_api/tests/test_views/test_submission_views/test_submission_views.py
+++ b/autograder/rest_api/tests/test_views/test_submission_views/test_submission_views.py
@@ -1591,9 +1591,9 @@ class RemoveFromQueueTestCase(test_data.Client,
                     submission, user)
 
     def test_error_remove_submission_not_in_queue(self):
-        statuses = set(Submission.GradingStatus.values)
-        statuses.remove(Submission.GradingStatus.queued)
-        statuses.remove(Submission.GradingStatus.received)
+        statuses = set(ag_models.Submission.GradingStatus.values)
+        statuses.remove(ag_models.Submission.GradingStatus.queued)
+        statuses.remove(ag_models.Submission.GradingStatus.received)
         for submission in self.all_submissions(self.visible_public_project):
             for grading_status in statuses:
                 submission.status = grading_status
@@ -1601,8 +1601,8 @@ class RemoveFromQueueTestCase(test_data.Client,
                 self.do_invalid_remove_from_queue_test(submission)
 
     def do_valid_remove_from_queue_test(self, submission, user=None):
-        for grading_status in (Submission.GradingStatus.received,
-                               Submission.GradingStatus.queued):
+        for grading_status in (ag_models.Submission.GradingStatus.received,
+                               ag_models.Submission.GradingStatus.queued):
             submission.status = grading_status
             submission.save()
 
@@ -1616,7 +1616,7 @@ class RemoveFromQueueTestCase(test_data.Client,
 
             submission.refresh_from_db()
 
-            self.assertEqual(Submission.GradingStatus.removed_from_queue,
+            self.assertEqual(ag_models.Submission.GradingStatus.removed_from_queue,
                              submission.status)
 
     def do_permission_denied_remove_from_queue_test(self, submission, user):

--- a/autograder/rest_api/urls.py
+++ b/autograder/rest_api/urls.py
@@ -209,6 +209,10 @@ urlpatterns = [
         views.CreateSoloGroupView.as_view({'post': 'create'}),
         name='solo_group'),
 
+    path('groups/<int:pk>/submissions_with_results/',
+         views.ListSubmissionsWithResults.as_view(),
+         name='list-submissions-with-results'),
+
     path('submissions/<int:pk>/results/',
          views.SubmissionResultsView.as_view(),
          name='submission-results'),

--- a/autograder/rest_api/views/__init__.py
+++ b/autograder/rest_api/views/__init__.py
@@ -37,7 +37,11 @@ from .rerun_submissions_task_views import (
 from .student_test_suite_views import (
     StudentTestSuiteListCreateView, StudentTestSuiteOrderView, StudentTestSuiteDetailViewSet)
 
-from .submission_views.submission_views import ListCreateSubmissionViewSet, SubmissionDetailViewSet
+from .submission_views.submission_views import (
+    ListCreateSubmissionViewSet,
+    ListSubmissionsWithResults,
+    SubmissionDetailViewSet
+)
 
 from .submission_views.submission_result_views import (
     SubmissionResultsView,

--- a/autograder/rest_api/views/submission_views/common.py
+++ b/autograder/rest_api/views/submission_views/common.py
@@ -1,0 +1,46 @@
+from drf_yasg.openapi import Parameter
+from rest_framework.exceptions import ValidationError
+
+import autograder.core.models as ag_models
+
+FDBK_CATEGORY_PARAM = 'feedback_category'
+
+
+def validate_fdbk_category(fdbk_category: str) -> ag_models.FeedbackCategory:
+    try:
+            return ag_models.FeedbackCategory(fdbk_category)
+    except ValueError:
+        raise ValidationError({
+            FDBK_CATEGORY_PARAM: 'Invalid value: {}'.format(fdbk_category)
+        })
+
+
+def make_fdbk_category_param_docs(*, required: bool=True, in_: str='query'):
+    return Parameter(
+        name=FDBK_CATEGORY_PARAM,
+        in_=in_,
+        required=required,
+        type='string',
+        enum=[item.value for item in ag_models.FeedbackCategory],
+        description=f"""
+The category of feedback being requested. Must be one of the following
+values:
+
+    - {ag_models.FeedbackCategory.normal.value}: Can be requested by
+        students before or after the project deadline on their
+        submissions that did not exceed the daily limit.
+    - {ag_models.FeedbackCategory.past_limit_submission.value}: Can be
+        requested by students on their submissions that exceeded the
+        daily limit.
+    - {ag_models.FeedbackCategory.ultimate_submission.value}: Can be
+        requested by students on their own ultimate (a.k.a. final
+        graded) submission once the project deadline has passed and
+        hide_ultimate_submission_fdbk has been set to False on the
+        project. Can similarly be requested by staff when looking
+        up another user's ultimate submission results after the
+        deadline.
+    - {ag_models.FeedbackCategory.staff_viewer.value}: Can be requested
+        by staff when looking up another user's submission results.
+    - {ag_models.FeedbackCategory.max.value}: Can be requested by staff
+        on their own submissions."""
+    )

--- a/autograder/rest_api/views/submission_views/submission_result_views.py
+++ b/autograder/rest_api/views/submission_views/submission_result_views.py
@@ -17,7 +17,7 @@ from autograder.core.caching import get_cached_submission_feedback
 from autograder.core.models.submission import get_submissions_with_results_queryset
 from autograder.core.submission_feedback import (
     SubmissionResultFeedback, AGTestSuiteResultFeedback, AGTestCommandResultFeedback,
-    AGTestPreLoader)
+    AGTestPreLoader, StudentTestSuitePreLoader)
 from autograder.rest_api.views.ag_model_views import AGModelAPIView, require_query_params
 from autograder.rest_api.views.schema_generation import APITags, AGModelSchemaBuilder
 from autograder.rest_api.serialize_ultimate_submission_results import (
@@ -47,7 +47,10 @@ class SubmissionResultsViewBase(AGModelAPIView):
     ) -> SubmissionResultFeedback:
         submission = self.get_object()
         return SubmissionResultFeedback(
-            submission, fdbk_category, AGTestPreLoader(submission.project))
+            submission,
+            fdbk_category,
+            AGTestPreLoader(submission.project)
+        )
 
     def _make_response(self, submission_fdbk: SubmissionResultFeedback,
                        fdbk_category: ag_models.FeedbackCategory):
@@ -75,7 +78,10 @@ class SubmissionResultsView(SubmissionResultsViewBase):
         model_manager = get_submissions_with_results_queryset(base_manager=self.model_manager)
         submission = self.get_object(model_manager_override=model_manager)
         return SubmissionResultFeedback(
-            submission, fdbk_category, AGTestPreLoader(submission.project))
+            submission,
+            fdbk_category,
+            AGTestPreLoader(submission.project)
+        )
 
     def _make_response(self, submission_fdbk: SubmissionResultFeedback,
                        fdbk_category: ag_models.FeedbackCategory):

--- a/autograder/rest_api/views/submission_views/submission_result_views.py
+++ b/autograder/rest_api/views/submission_views/submission_result_views.py
@@ -483,7 +483,7 @@ class StudentTestSuiteOutputSizeView(SubmissionResultsViewBase):
         if result is None:
             return response.Response(None)
 
-        fdbk = result.get_fdbk(fdbk_category)
+        fdbk = result.get_fdbk(fdbk_category, submission_fdbk.student_test_suite_preloader)
         return response.Response({
             'setup_stdout_size': fdbk.get_setup_stdout_size(),
             'setup_stderr_size': fdbk.get_setup_stderr_size(),
@@ -509,7 +509,8 @@ def _get_student_suite_result_output_field(
     if result is None:
         return response.Response(None)
 
-    output_stream = get_output_fn(result.get_fdbk(fdbk_category))
+    output_stream = get_output_fn(
+        result.get_fdbk(fdbk_category, submission_fdbk.student_test_suite_preloader))
     if output_stream is None:
         return response.Response(None)
 

--- a/autograder/rest_api/views/submission_views/submission_views.py
+++ b/autograder/rest_api/views/submission_views/submission_views.py
@@ -15,7 +15,8 @@ from drf_yasg.utils import swagger_auto_schema
 from rest_framework import decorators, exceptions, mixins, response, status
 
 import autograder.core.models as ag_models
-from autograder.core.submission_feedback import AGTestPreLoader, SubmissionResultFeedback
+from autograder.core.submission_feedback import (
+    AGTestPreLoader, StudentTestSuitePreLoader, SubmissionResultFeedback)
 import autograder.rest_api.permissions as ag_permissions
 import autograder.rest_api.serializers as ag_serializers
 from autograder.rest_api.serialize_ultimate_submission_results import (
@@ -265,6 +266,7 @@ class ListSubmissionsWithResults(AGModelAPIView):
             base_manager=group.submissions)
 
         ag_test_preloader = AGTestPreLoader(group.project)
+        student_test_suite_preloader = StudentTestSuitePreLoader(group.project)
 
         submissions = []
         for submission in submissions_queryset:
@@ -279,7 +281,12 @@ class ListSubmissionsWithResults(AGModelAPIView):
                 fdbk_category = ag_models.FeedbackCategory.normal
 
             serialized = get_submission_data_with_results(
-                SubmissionResultFeedback(submission, fdbk_category, ag_test_preloader),
+                SubmissionResultFeedback(
+                    submission,
+                    fdbk_category,
+                    ag_test_preloader,
+                    student_test_suite_preloader
+                ),
                 full_results=True
             )
             submissions.append(serialized)

--- a/autograder/utils/testing/unit_test_base.py
+++ b/autograder/utils/testing/unit_test_base.py
@@ -87,6 +87,9 @@ class _SetUpTearDownCommon:
     IMPORTANT: Classes inheriting from this mixin should override the
     MEDIA_ROOT setting, such as with this decorator:
         @override_settings(MEDIA_ROOT=os.path.join(settings.PROJECT_ROOT, 'tmp_filesystem'))
+
+    NOTE: Avoid using setUpTestData until we implement some sort of filesystem
+    rollback behavior.
     """
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
This allows for much more efficient loading of all submissions for a single group.