### PR TITLE
Wrote SizeFileResponse to set Content-Length

### DIFF
--- a/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
+++ b/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
@@ -110,6 +110,7 @@ class RetrieveHandgradingResultTestCase(_SetUp):
             for file_ in self.submitted_files:
                 response = self.client.get(self.get_file_url(file_.name))
                 self.assertEqual(status.HTTP_200_OK, response.status_code)
+                self.assertIn('Content-Length', response)
                 file_.seek(0)
                 self.assertEqual(file_.read(),
                                  b''.join((chunk for chunk in response.streaming_content)))

--- a/autograder/handgrading/views/handgrading_result_views.py
+++ b/autograder/handgrading/views/handgrading_result_views.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 
 from django.contrib.auth.models import User
 from django.db.models import Prefetch
-from django.http import FileResponse
 from django.db import transaction
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from drf_yasg import openapi
@@ -22,6 +21,7 @@ from autograder.core.models.get_ultimate_submissions import get_ultimate_submiss
 import autograder.handgrading.models as handgrading_models
 import autograder.handgrading.serializers as handgrading_serializers
 import autograder.rest_api.permissions as ag_permissions
+from autograder.rest_api.size_file_response import SizeFileResponse
 from autograder.rest_api.views.ag_model_views import (
     handle_object_does_not_exist_404, AGModelAPIView, AGModelGenericViewSet)
 from autograder import utils
@@ -79,7 +79,7 @@ class HandgradingResultView(AGModelGenericViewSet):
         submission = group.handgrading_result.submission
 
         filename = request.query_params['filename']
-        return FileResponse(submission.get_file(filename))
+        return SizeFileResponse(submission.get_file(filename))
 
     @transaction.atomic()
     def create(self, *args, **kwargs):

--- a/autograder/rest_api/size_file_response.py
+++ b/autograder/rest_api/size_file_response.py
@@ -1,0 +1,17 @@
+from django.http import FileResponse
+
+
+# Django's FileResponse.set_headers doesn't set the Content-Length
+# header if the 'name' attribute of the file-like object it's given
+# is a relative path. Unfortunately, that seems to be the case with
+# FieldFiles (it's name is the relative path from MEDIA_ROOT).
+# See https://docs.djangoproject.com/en/2.2/_modules/django/http/response/#FileResponse
+#
+# This class overrides set_headers such that if Content-Length hasn't
+# been set and the file-like object has a 'size' attribute,
+# Content-Length is set to the value of that attribute.
+class SizeFileResponse(FileResponse):
+    def set_headers(self, filelike):
+        super().set_headers(filelike)
+        if 'Content-Length' not in self and hasattr(filelike, 'size'):
+            self['Content-Length'] = filelike.size

--- a/autograder/rest_api/tests/test_views/test_project_views/test_instructor_file_views.py
+++ b/autograder/rest_api/tests/test_views/test_project_views/test_instructor_file_views.py
@@ -241,6 +241,7 @@ class RetrieveUploadedFileContentTestCase(_BuildFile,
         client.force_authenticate(user)
         response = client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertIn('Content-Length', response)
         self.assertEqual(
             expected_content,
             b''.join((chunk for chunk in response.streaming_content)))

--- a/autograder/rest_api/tests/test_views/test_project_views/test_project_views.py
+++ b/autograder/rest_api/tests/test_views/test_project_views/test_project_views.py
@@ -569,6 +569,7 @@ class DownloadTaskEndpointsTestCase(UnitTestBase):
             self.client.force_authenticate(user)
             response = self.client.get(url)
             self.assertEqual(status.HTTP_200_OK, response.status_code)
+            self.assertIn('Content-Length', response)
             self.assertEqual(f.read(), b''.join((chunk for chunk in response.streaming_content)))
 
     def test_invalid_get_in_progress_download_task_result(self):

--- a/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_submission_result_views.py
+++ b/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_submission_result_views.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 
-from django.http import FileResponse, QueryDict
+from django.http import QueryDict
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -123,6 +123,7 @@ class _FeedbackTestsBase(UnitTestBase):
         if expected is None:
             self.assertIsNone(response.data)
         else:
+            self.assertIn('Content-Length', response)
             self.assertEqual(
                 expected.read(), b''.join((chunk for chunk in response.streaming_content)))
 

--- a/autograder/rest_api/tests/test_views/test_submission_views/test_submission_views.py
+++ b/autograder/rest_api/tests/test_views/test_submission_views/test_submission_views.py
@@ -1241,6 +1241,7 @@ class RetrieveSubmissionAndFileTestCase(test_data.Client,
         client.force_authenticate(user)
         response = client.get(url)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertIn('Content-Length', response)
         self.assertEqual(
             expected_content,
             b''.join((chunk for chunk in response.streaming_content)))

--- a/autograder/rest_api/views/project_views/instructor_file_views.py
+++ b/autograder/rest_api/views/project_views/instructor_file_views.py
@@ -1,6 +1,5 @@
 from django.core import exceptions
 from django.db import transaction
-from django.http import FileResponse
 from django.utils.decorators import method_decorator
 from drf_yasg.openapi import Parameter
 from drf_yasg.utils import swagger_auto_schema
@@ -11,6 +10,7 @@ import autograder.rest_api.permissions as ag_permissions
 import autograder.rest_api.serializers as ag_serializers
 from autograder.core import constants
 from autograder.rest_api import transaction_mixins
+from autograder.rest_api.size_file_response import SizeFileResponse
 from autograder.rest_api.views.ag_model_views import (
     ListCreateNestedModelViewSet, AGModelGenericViewSet, require_body_params, AGModelAPIView)
 from autograder.rest_api.views.schema_generation import APITags
@@ -97,7 +97,7 @@ class InstructorFileContentView(AGModelAPIView):
     @swagger_auto_schema(response_content_type='text/html',
                          responses={'200': 'Returns the file contents.'})
     def get(self, *args, **kwargs):
-        return FileResponse(self.get_object().file_obj)
+        return SizeFileResponse(self.get_object().file_obj)
 
     @swagger_auto_schema(request_body_parameters=_update_content_params,
                          responses={'200': 'Returns the updated InstructorFile metadata.'})

--- a/autograder/rest_api/views/project_views/project_views.py
+++ b/autograder/rest_api/views/project_views/project_views.py
@@ -1,6 +1,5 @@
 from django.db import transaction
 from django.db.models import F, Case, When
-from django.http import FileResponse
 from django.shortcuts import get_object_or_404
 from drf_composable_permissions.p import P
 from drf_yasg.openapi import Parameter, Schema
@@ -19,6 +18,7 @@ import autograder.handgrading.models as hg_models
 import autograder.handgrading.serializers as hg_serializers
 from autograder.handgrading.import_handgrading_rubric import import_handgrading_rubric
 from autograder.rest_api import tasks as api_tasks, transaction_mixins
+from autograder.rest_api.size_file_response import SizeFileResponse
 from autograder.rest_api.views.ag_model_views import (
     AGModelGenericViewSet, convert_django_validation_error, handle_object_does_not_exist_404,
     AGModelAPIView)
@@ -277,7 +277,7 @@ class DownloadTaskDetailViewSet(mixins.RetrieveModelMixin, AGModelGenericViewSet
                                      status=status.HTTP_400_BAD_REQUEST)
 
         content_type = self._get_content_type(task.download_type)
-        return FileResponse(open(task.result_filename, 'rb'), content_type=content_type)
+        return SizeFileResponse(open(task.result_filename, 'rb'), content_type=content_type)
 
     def _get_content_type(self, download_type: ag_models.DownloadType):
         if (download_type == ag_models.DownloadType.all_scores

--- a/autograder/rest_api/views/submission_views/submission_views.py
+++ b/autograder/rest_api/views/submission_views/submission_views.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from django.db.models import F
-from django.http.response import FileResponse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from drf_composable_permissions.p import P
@@ -21,6 +20,7 @@ import autograder.rest_api.permissions as ag_permissions
 import autograder.rest_api.serializers as ag_serializers
 from autograder.rest_api.serialize_ultimate_submission_results import (
     get_submission_data_with_results)
+from autograder.rest_api.size_file_response import SizeFileResponse
 import autograder.utils.testing as test_ut
 from autograder.rest_api import transaction_mixins
 from autograder.rest_api.views.ag_model_views import (
@@ -319,7 +319,7 @@ class SubmissionDetailViewSet(mixins.RetrieveModelMixin,
         submission = self.get_object()
         filename = request.query_params['filename']
         try:
-            return FileResponse(submission.get_file(filename))
+            return SizeFileResponse(submission.get_file(filename))
         except ObjectDoesNotExist:
             return response.Response('File "{}" not found'.format(filename),
                                      status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Wrote a FileResponse wrapper class that sets Content-Length even if the file-like object path is relative.