### PR TITLE
Refactored code that constructs XXResultFeedback object lists.

### DIFF
--- a/autograder/core/models/ag_test/ag_test_suite.py
+++ b/autograder/core/models/ag_test/ag_test_suite.py
@@ -1,5 +1,5 @@
 from django.core import exceptions
-from django.db import models, connection
+from django.db import models, connection, transaction
 
 import autograder.core.fields as ag_fields
 from autograder.core import constants
@@ -221,6 +221,7 @@ class AGTestSuite(AutograderModel):
         if errors:
             raise exceptions.ValidationError(errors)
 
+    @transaction.atomic()
     def delete(self, *args, **kwargs):
         with connection.cursor() as cursor:
             cursor.execute(

--- a/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
@@ -353,3 +353,21 @@ class SubmissionFeedbackTestCase(UnitTestBase):
         actual = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max).to_dict()
         print(json.dumps(actual, indent=4, sort_keys=True))
         self.assertEqual(expected, actual)
+
+    def test_denormalized_data_updated_on_missing_suite_key_error(self) -> None:
+        self.ag_test_suite1.delete()
+        result = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
+        self.assertNotIn(self.ag_test_suite1, result.ag_test_suite_results)
+
+    def test_denormalized_data_updated_on_missing_ag_test_case_key_error(self) -> None:
+        self.ag_test_case2.delete()
+        result = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
+        for suite_res in result.ag_test_suite_results:
+            self.assertNotIn(self.ag_test_case2, suite_res.ag_test_case_results)
+
+    def test_denormalized_data_updated_on_missing_command_key_error(self) -> None:
+        self.ag_test_cmd1.delete()
+        result = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
+        for suite_res in result.ag_test_suite_results:
+            for test_res in suite_res.ag_test_case_results:
+                self.assertNotIn(self.ag_test_cmd1, test_res.ag_test_command_results)


### PR DESCRIPTION
Added logic to catch KeyError (indicating something was deleted) and skip the affected objects.
Also ended up simplifying the code by using a single loop rather than several layers of iterators.

Fixes #479