### PR TITLE
Changed the way the API handles stdout/stderr truncated data.

### DIFF
--- a/autograder/core/submission_feedback.py
+++ b/autograder/core/submission_feedback.py
@@ -505,7 +505,10 @@ class AGTestSuiteResultFeedback(ToDictMixin):
         return os.path.getsize(self._ag_test_suite_result.setup_stdout_filename)
 
     @property
-    def setup_stdout_truncated(self) -> bool:
+    def setup_stdout_truncated(self) -> Optional[bool]:
+        if not self._fdbk.show_setup_stderr:
+            return None
+
         return self._ag_test_suite_result.setup_stdout_truncated
 
     @property
@@ -522,7 +525,10 @@ class AGTestSuiteResultFeedback(ToDictMixin):
         return os.path.getsize(self._ag_test_suite_result.setup_stderr_filename)
 
     @property
-    def setup_stderr_truncated(self) -> bool:
+    def setup_stderr_truncated(self) -> Optional[bool]:
+        if not self._fdbk.show_setup_stderr:
+            return None
+
         return self._ag_test_suite_result.setup_stderr_truncated
 
     @property
@@ -586,9 +592,6 @@ class AGTestSuiteResultFeedback(ToDictMixin):
         'setup_name',
         'setup_return_code',
         'setup_timed_out',
-
-        'setup_stdout_truncated',
-        'setup_stderr_truncated',
 
         'ag_test_case_results'
     )
@@ -844,8 +847,11 @@ class AGTestCommandResultFeedback(ToDictMixin):
                 or self._fdbk.stdout_fdbk_level == ValueFeedbackLevel.expected_and_actual)
 
     @property
-    def stdout_truncated(self) -> bool:
-        return self._ag_test_command_result.stdout_truncated
+    def stdout_truncated(self) -> Optional[bool]:
+        if self._show_actual_stdout:
+            return self._ag_test_command_result.stdout_truncated
+
+        return None
 
     @property
     def stdout_diff(self) -> Optional[core_ut.DiffResult]:
@@ -910,24 +916,28 @@ class AGTestCommandResultFeedback(ToDictMixin):
 
     @property
     def stderr(self) -> Optional[BinaryIO]:
-        if self._show_actual_stderr():
+        if self._show_actual_stderr:
             return open(self._ag_test_command_result.stderr_filename, 'rb')
 
         return None
 
     def get_stderr_size(self) -> Optional[int]:
-        if self._show_actual_stderr():
+        if self._show_actual_stderr:
             return os.path.getsize(self._ag_test_command_result.stderr_filename)
 
         return None
 
+    @property
     def _show_actual_stderr(self):
         return (self._fdbk.show_actual_stderr
                 or self._fdbk.stderr_fdbk_level == ValueFeedbackLevel.expected_and_actual)
 
     @property
-    def stderr_truncated(self) -> bool:
-        return self._ag_test_command_result.stderr_truncated
+    def stderr_truncated(self) -> Optional[bool]:
+        if self._show_actual_stderr:
+            return self._ag_test_command_result.stderr_truncated
+
+        return None
 
     @property
     def stderr_diff(self) -> Optional[core_ut.DiffResult]:
@@ -1013,12 +1023,10 @@ class AGTestCommandResultFeedback(ToDictMixin):
         'stdout_correct',
         'stdout_points',
         'stdout_points_possible',
-        'stdout_truncated',
 
         'stderr_correct',
         'stderr_points',
         'stderr_points_possible',
-        'stderr_truncated',
 
         'total_points',
         'total_points_possible'

--- a/autograder/core/tests/test_submission_feedback/test_ag_test_command_result_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_ag_test_command_result_feedback.py
@@ -514,11 +514,13 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
             }
         )
         result = self.make_correct_result()
+        result.stdout_truncated = True
         fdbk = get_cmd_fdbk(result, ag_models.FeedbackCategory.normal)
 
         self.assertEqual(len(_stdout_text(result)), fdbk.get_stdout_size())
         self.assertEqual(_stdout_text(result), _stdout_text(fdbk))
         self.assertIsNone(fdbk.stdout_correct)
+        self.assertTrue(fdbk.stdout_truncated)
         self.assertEqual(0, fdbk.stdout_points)
         self.assertEqual(0, fdbk.stdout_points_possible)
 
@@ -535,6 +537,7 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
         self.assertIsNone(fdbk.get_stdout_size())
         self.assertIsNone(fdbk.stdout)
         self.assertTrue(fdbk.stdout_correct)
+        self.assertIsNone(fdbk.stdout_truncated)
         self.assertIsNone(fdbk.get_stdout_diff_size())
         self.assertIsNone(fdbk.stdout_diff)
         self.assertEqual(self.ag_test_command.points_for_correct_stdout,
@@ -556,6 +559,7 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
         self.assertIsNotNone(fdbk.stdout_diff)
         self.assertIsNotNone(fdbk.get_stdout_size())
         self.assertIsNotNone(fdbk.stdout)
+        self.assertIsNotNone(fdbk.stdout_truncated)
         self.assertEqual(self.ag_test_command.points_for_correct_stdout,
                          fdbk.stdout_points)
 
@@ -675,11 +679,13 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
             }
         )
         result = self.make_correct_result()
+        result.stderr_truncated = True
         fdbk = get_cmd_fdbk(result, ag_models.FeedbackCategory.normal)
 
         self.assertEqual(len(_stderr_text(result)), fdbk.get_stderr_size())
         self.assertEqual(_stderr_text(result), _stderr_text(fdbk))
         self.assertIsNone(fdbk.stderr_correct)
+        self.assertTrue(fdbk.stderr_truncated)
         self.assertEqual(0, fdbk.stderr_points)
         self.assertEqual(0, fdbk.stderr_points_possible)
 
@@ -695,6 +701,7 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
 
         self.assertIsNone(fdbk.stderr)
         self.assertIsNone(fdbk.get_stderr_size())
+        self.assertIsNone(fdbk.stderr_truncated)
         self.assertTrue(fdbk.stderr_correct)
         self.assertIsNone(fdbk.stderr_diff)
         self.assertIsNone(fdbk.get_stderr_diff_size())
@@ -717,6 +724,7 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
         self.assertIsNotNone(fdbk.get_stderr_diff_size())
         self.assertIsNotNone(fdbk.stderr)
         self.assertIsNotNone(fdbk.get_stderr_size())
+        self.assertFalse(fdbk.stderr_truncated)
         self.assertEqual(self.ag_test_command.points_for_correct_stderr,
                          fdbk.stderr_points)
 
@@ -840,12 +848,10 @@ class AGTestCommandResultFeedbackTestCase(UnitTestBase):
             'stdout_correct',
             'stdout_points',
             'stdout_points_possible',
-            'stdout_truncated',
 
             'stderr_correct',
             'stderr_points',
             'stderr_points_possible',
-            'stderr_truncated',
 
             'total_points',
             'total_points_possible',

--- a/autograder/core/tests/test_submission_feedback/test_ag_test_suite_result_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_ag_test_suite_result_feedback.py
@@ -162,6 +162,7 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
             f.write(setup_stderr)
         self.ag_test_suite_result.save()
 
+        self.ag_test_suite_result.setup_stdout_truncated = True
         fdbk = get_suite_fdbk(self.ag_test_suite_result, ag_models.FeedbackCategory.max)
         self.assertEqual(self.ag_test_suite.setup_suite_cmd_name, fdbk.setup_name)
         self.assertEqual(setup_return_code, fdbk.setup_return_code)
@@ -170,6 +171,8 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
         self.assertEqual(len(setup_stdout), fdbk.get_setup_stdout_size())
         self.assertEqual(setup_stderr, fdbk.setup_stderr.read().decode())
         self.assertEqual(len(setup_stderr), fdbk.get_setup_stderr_size())
+        self.assertTrue(fdbk.setup_stdout_truncated)
+        self.assertFalse(fdbk.setup_stderr_truncated)
 
         self.ag_test_suite.validate_and_update(
             normal_fdbk_config={
@@ -188,6 +191,8 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
         self.assertIsNone(fdbk.get_setup_stdout_size())
         self.assertIsNone(fdbk.setup_stderr)
         self.assertIsNone(fdbk.get_setup_stderr_size())
+        self.assertIsNone(fdbk.setup_stdout_truncated)
+        self.assertIsNone(fdbk.setup_stderr_truncated)
 
     def test_some_ag_test_cases_not_visible(self):
         self.ag_test_case2.validate_and_update(ultimate_submission_fdbk_config={'visible': False})
@@ -213,8 +218,6 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
             'setup_name',
             'setup_return_code',
             'setup_timed_out',
-            'setup_stdout_truncated',
-            'setup_stderr_truncated',
             'total_points',
             'total_points_possible',
             'ag_test_case_results',

--- a/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_ag_test_suite_and_command_output_fdbk.py
+++ b/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_ag_test_suite_and_command_output_fdbk.py
@@ -164,6 +164,8 @@ class AGTestSuiteOutputFeedbackTestCase(_SetUp):
             expected = {
                 'setup_stdout_size': fdbk.get_setup_stdout_size(),
                 'setup_stderr_size': fdbk.get_setup_stderr_size(),
+                'setup_stdout_truncated': fdbk.setup_stdout_truncated,
+                'setup_stderr_truncated': fdbk.setup_stderr_truncated,
             }
             self.assertEqual(expected, response.data)
 

--- a/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_submission_result_views.py
+++ b/autograder/rest_api/tests/test_views/test_submission_views/test_submission_result_views/test_submission_result_views.py
@@ -112,6 +112,8 @@ class _FeedbackTestsBase(UnitTestBase):
         expected = {
             'stdout_size': cmd_fdbk.get_stdout_size(),
             'stderr_size': cmd_fdbk.get_stderr_size(),
+            'stdout_truncated': cmd_fdbk.stdout_truncated,
+            'stderr_truncated': cmd_fdbk.stderr_truncated,
             'stdout_diff_size': cmd_fdbk.get_stdout_diff_size(),
             'stderr_diff_size': cmd_fdbk.get_stderr_diff_size(),
         }

--- a/autograder/rest_api/views/submission_views/submission_result_views.py
+++ b/autograder/rest_api/views/submission_views/submission_result_views.py
@@ -133,7 +133,13 @@ class AGTestSuiteResultsStderrView(SubmissionResultsViewBase):
             type='object',
             properties={
                 'setup_stdout_size': Parameter('setup_stdout_size', 'body', type='Optional[int]'),
+                'setup_stdout_truncated': Parameter(
+                    'setup_stdout_truncated', 'body', type='Optional[bool]'),
+
                 'setup_stderr_size': Parameter('setup_stderr_size', 'body', type='Optional[int]'),
+                'setup_stderr_truncated': Parameter(
+                    'setup_stderr_truncated', 'body', type='Optional[bool]'),
+
             }
         )}
     )
@@ -147,7 +153,9 @@ class AGTestSuiteResultsOutputSizeView(SubmissionResultsViewBase):
             return response.Response(None)
         return response.Response({
             'setup_stdout_size': suite_fdbk.get_setup_stdout_size(),
+            'setup_stdout_truncated': suite_fdbk.setup_stdout_truncated,
             'setup_stderr_size': suite_fdbk.get_setup_stderr_size(),
+            'setup_stderr_truncated': suite_fdbk.setup_stderr_truncated,
         })
 
 
@@ -220,7 +228,9 @@ class AGTestCommandResultStderrView(SubmissionResultsViewBase):
             type='object',
             properties={
                 'stdout_size': Parameter('stdout_size', 'body', type='Optional[int]'),
+                'stdout_truncated': Parameter('stdout_truncated', 'body', type='Optional[bool]'),
                 'stderr_size': Parameter('stderr_size', 'body', type='Optional[int]'),
+                'stderr_truncated': Parameter('stderr_truncated', 'body', type='Optional[bool]'),
                 'stdout_diff_size': Parameter('stdout_diff_size', 'body', type='Optional[int]'),
                 'stderr_diff_size': Parameter('stderr_diff_size', 'body', type='Optional[int]'),
             }
@@ -236,7 +246,9 @@ class AGTestCommandResultOutputSizeView(SubmissionResultsViewBase):
             return response.Response(None)
         return response.Response({
             'stdout_size': cmd_fdbk.get_stdout_size(),
+            'stdout_truncated': cmd_fdbk.stdout_truncated,
             'stderr_size': cmd_fdbk.get_stderr_size(),
+            'stderr_truncated': cmd_fdbk.stderr_truncated,
             'stdout_diff_size': cmd_fdbk.get_stdout_diff_size(),
             'stderr_diff_size': cmd_fdbk.get_stderr_diff_size(),
         })


### PR DESCRIPTION
Addendum to #493 

These fields are now included in the output size endpoints instead of in the main body of the result feedback objects.

