### PR TITLE
Added the --text flag to diff calls.

### DIFF
--- a/autograder/core/tests/test_utils.py
+++ b/autograder/core/tests/test_utils.py
@@ -113,6 +113,21 @@ cheese\r
         diff = core_ut.get_diff(self.file1.name, self.file2.name)
         self.assertEqual(expected_diff, diff.diff_content)
 
+    # If diff sees a null byte, it will just print
+    # "Binary Files X and Y differ" by default. We want to make sure
+    # that we are passing the --text flag to diff.
+    def test_text_flag_passed_to_gnu_diff(self) -> None:
+        non_utf_bytes = b'\x00 I am null byte\n'
+
+        self._write_and_seek(self.file1, b'some stuff')
+        self._write_and_seek(self.file2, non_utf_bytes)
+
+        expected_diff = [
+            '- some stuff',
+            '+ ' + non_utf_bytes.decode('utf-8', 'surrogateescape')]
+        diff = core_ut.get_diff(self.file1.name, self.file2.name)
+        self.assertEqual(expected_diff, diff.diff_content)
+
     def test_ignore_case(self):
         self._write_and_seek(self.file1, 'SPAM')
         self._write_and_seek(self.file2, 'spam')

--- a/autograder/core/utils.py
+++ b/autograder/core/utils.py
@@ -37,6 +37,7 @@ def get_diff(first_filename: str, second_filename: str,
     # because GNU diff will otherwise handle missing trailing
     # newlines in a way that the client can't reliably parse.
     diff_cmd = ['diff',
+                '--text',  # Consider all files to be text
                 '--new-line-format', '+ %L\n',
                 '--old-line-format', '- %L\n',
                 '--unchanged-line-format', '  %L\n']


### PR DESCRIPTION
This flag forces diff to treat files as text, so we won't get the 'Binary files differ' message.

Fixes #483