### PR TITLE
Fixed issues with previous changes in pr #507

### DIFF
--- a/autograder/core/submission_feedback.py
+++ b/autograder/core/submission_feedback.py
@@ -534,7 +534,7 @@ class AGTestSuiteResultFeedback(ToDictMixin):
     @property
     def _show_setup_name(self):
         has_setup_result = (self._ag_test_suite_result.setup_return_code is not None
-                            or self._ag_test_suite_result.setup_timed_out is not None)
+                            or self._ag_test_suite_result.setup_timed_out)
         setup_info_is_available = (
             self._fdbk.show_setup_stdout
             or self._fdbk.show_setup_stderr

--- a/autograder/core/tests/test_submission_feedback/test_ag_test_suite_result_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_ag_test_suite_result_feedback.py
@@ -194,7 +194,7 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
         self.assertIsNone(fdbk.setup_stdout_truncated)
         self.assertIsNone(fdbk.setup_stderr_truncated)
 
-    def test_show_setup_name_with_return_code_non_null_and_timed_out_null(self) -> None:
+    def test_show_setup_name_with_return_code_non_null_and_timed_out_false(self) -> None:
         self.ag_test_suite.validate_and_update(
             normal_fdbk_config={
                 'show_setup_return_code': False,
@@ -205,12 +205,13 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
         )
 
         self.ag_test_suite_result.setup_return_code = 42
-        self.ag_test_suite_result.setup_timed_out = None
+        self.ag_test_suite_result.setup_timed_out = False
+        self.ag_test_suite_result.save()
 
         fdbk = get_suite_fdbk(self.ag_test_suite_result, ag_models.FeedbackCategory.normal)
         self.assertEqual(self.ag_test_suite.setup_suite_cmd_name, fdbk.setup_name)
 
-    def test_show_setup_name_with_return_code_null_and_timed_out_non_null(self) -> None:
+    def test_show_setup_name_with_return_code_null_and_timed_out_true(self) -> None:
         self.ag_test_suite.validate_and_update(
             normal_fdbk_config={
                 'show_setup_return_code': False,
@@ -222,13 +223,15 @@ class AGTestSuiteFeedbackTestCase(UnitTestBase):
 
         self.ag_test_suite_result.setup_return_code = None
         self.ag_test_suite_result.setup_timed_out = True
+        self.ag_test_suite_result.save()
 
         fdbk = get_suite_fdbk(self.ag_test_suite_result, ag_models.FeedbackCategory.normal)
         self.assertEqual(self.ag_test_suite.setup_suite_cmd_name, fdbk.setup_name)
 
-    def test_show_setup_name_with_return_code_and_timed_out_null(self) -> None:
+    def test_show_setup_name_with_return_code_null_and_timed_out_false(self) -> None:
         self.ag_test_suite_result.setup_return_code = None
-        self.ag_test_suite_result.setup_timed_out = None
+        self.ag_test_suite_result.setup_timed_out = False
+        self.ag_test_suite_result.save()
 
         fdbk = get_suite_fdbk(self.ag_test_suite_result, ag_models.FeedbackCategory.max)
         self.assertIsNone(fdbk.setup_name)

--- a/autograder/grading_tasks/tasks/grade_ag_test.py
+++ b/autograder/grading_tasks/tasks/grade_ag_test.py
@@ -86,7 +86,15 @@ def grade_ag_test_suite_impl(ag_test_suite: ag_models.AGTestSuite,
 def _run_suite_setup(sandbox: AutograderSandbox,
                      ag_test_suite: ag_models.AGTestSuite,
                      suite_result: ag_models.AGTestSuiteResult):
+    @retry_should_recover
+    def _save_suite_result():
+        suite_result.save()
+
     if not ag_test_suite.setup_suite_cmd:
+        suite_result.setup_return_code = None
+        suite_result.setup_timed_out = False
+        _save_suite_result()
+
         # Erase the setup output files.
         with open(suite_result.setup_stdout_filename, 'wb') as f:
             pass
@@ -111,10 +119,6 @@ def _run_suite_setup(sandbox: AutograderSandbox,
         shutil.copyfileobj(setup_result.stdout, f)
     with open(suite_result.setup_stderr_filename, 'wb') as f:
         shutil.copyfileobj(setup_result.stderr, f)
-
-    @retry_should_recover
-    def _save_suite_result():
-        suite_result.save()
 
     _save_suite_result()
 


### PR DESCRIPTION
- Changed instances of setup_timed_out being None to use False instead. (this field cannot be None in the DB)
- When there is no setup command, return code and timed out are now set to their default values.

See previous PR #507 