### PR TITLE
Made changes to grading queue system:

### DIFF
--- a/autograder/grading_tasks/tasks/grade_ag_test.py
+++ b/autograder/grading_tasks/tasks/grade_ag_test.py
@@ -21,7 +21,7 @@ from .utils import (FileCloser, add_files_to_sandbox, mark_submission_as_error,
                     run_ag_test_command, run_command_from_args)
 
 
-@celery.shared_task(bind=True, queue='deferred', max_retries=1, acks_late=True)
+@celery.shared_task(bind=True, max_retries=1, acks_late=True)
 def grade_deferred_ag_test_suite(self, ag_test_suite_pk, submission_pk):
     @retry_should_recover
     def _grade_deferred_ag_test_suite_impl():

--- a/autograder/grading_tasks/tasks/grade_student_test_suite.py
+++ b/autograder/grading_tasks/tasks/grade_student_test_suite.py
@@ -18,7 +18,7 @@ from .utils import (add_files_to_sandbox, mark_submission_as_error,
                     retry_should_recover, run_ag_command, run_ag_test_command)
 
 
-@celery.shared_task(queue='deferred', max_retries=1, acks_late=True)
+@celery.shared_task(max_retries=1, acks_late=True)
 def grade_deferred_student_test_suite(student_test_suite_pk, submission_pk):
 
     @retry_should_recover

--- a/autograder/grading_tasks/tasks/queueing.py
+++ b/autograder/grading_tasks/tasks/queueing.py
@@ -1,9 +1,28 @@
 import celery
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Sum, F
 
 import autograder.core.models as ag_models
 from .grade_submission import grade_submission
+
+
+def _estimated_grading_time(project_pk: int):
+    ag_test_time_max = sum(
+        command.time_limit for command in
+        ag_models.AGTestCommand.objects.filter(
+            ag_test_case__ag_test_suite__project=project_pk
+        ).exclude(ag_test_case__ag_test_suite__deferred=True)
+    )
+
+    student_test_suite_time_max = sum(
+        suite.student_test_validity_check_command.time_limit * suite.max_num_student_tests
+        for suite in
+        ag_models.StudentTestSuite.objects.filter(project=project_pk).exclude(deferred=True)
+    )
+
+    return ag_test_time_max + student_test_suite_time_max
+
 
 
 @celery.shared_task
@@ -17,8 +36,14 @@ def queue_submissions():
             print('adding submission{} to queue for grading'.format(submission.pk))
             submission.status = ag_models.Submission.GradingStatus.queued
             submission.save()
-            grade_submission.apply_async([submission.pk],
-                                         queue=_get_submission_queue_name(submission))
+
+            if _estimated_grading_time(submission.project_id) / 60 > 10:
+                queue_name_tmpl = settings.SUBMISSION_QUEUE_TMPL.format(submission.project_id)
+            else:
+                queue_name_tmpl = settings.FAST_QUEUE_TMPL.format(submission.project_id)
+
+            grade_submission.apply_async(
+                [submission.pk], queue=queue_name_tmpl.format(submission.project_id))
 
         print('queued {} submissions'.format(to_queue))
 
@@ -28,8 +53,10 @@ def register_project_queues(worker_names=None, project_pks=None):
     from autograder.celery import app
 
     if not worker_names:
-        worker_names = [worker_name for worker_name in app.control.inspect().active()
-                        if worker_name.startswith(settings.SUBMISSION_WORKER_PREFIX)]
+        worker_names = [
+            worker_name for worker_name in app.control.inspect().active() if
+            get_worker_prefix(worker_name) in settings.WORKER_PREFIX_TO_QUEUE_TMPLS
+        ]
 
     print('worker names', worker_names, flush=True)
     if not worker_names:
@@ -38,11 +65,14 @@ def register_project_queues(worker_names=None, project_pks=None):
     if not project_pks:
         project_pks = [project.pk for project in ag_models.Project.objects.all()]
 
-    print('project pks:', project_pks, flush=True)
-    for pk in project_pks:
-        res = app.control.add_consumer('project{}'.format(pk), destination=worker_names)
-        print(res)
+    for worker_name in worker_names:
+        prefix = get_worker_prefix(worker_name)
+        for pk in project_pks:
+            queue_tmpls = settings.WORKER_PREFIX_TO_QUEUE_TMPLS[prefix]
+            for tmpl in queue_tmpls:
+                res = app.control.add_consumer(tmpl.format(pk), destination=[worker_name])
+            print(res)
 
 
-def _get_submission_queue_name(submission: ag_models.Submission):
-    return 'project{}'.format(submission.group.project_id)
+def get_worker_prefix(worker_hostname: str):
+    return worker_hostname.split('@')[0]

--- a/autograder/grading_tasks/tasks/queueing.py
+++ b/autograder/grading_tasks/tasks/queueing.py
@@ -24,7 +24,6 @@ def _estimated_grading_time(project_pk: int):
     return ag_test_time_max + student_test_suite_time_max
 
 
-
 @celery.shared_task
 def queue_submissions():
     with transaction.atomic():

--- a/autograder/settings/celery_settings.py
+++ b/autograder/settings/celery_settings.py
@@ -34,3 +34,23 @@ CELERYBEAT_SCHEDULE = {
 }
 
 SUBMISSION_WORKER_PREFIX = 'submission_grader'
+FAST_GRADER_WORKER_PREFIX = 'fast_submission_grader'
+DEFERRED_WORKER_PREFIX = 'deferred'
+RERUN_WORKER_PREFIX = 'rerun'
+
+SUBMISSION_QUEUE_TMPL = 'project{}'
+FAST_QUEUE_TMPL = 'fast_project{}'
+DEFERRED_QUEUE_TMPL = 'deferred_project{}'
+RERUN_QUEUE_TMPL = 'rerun_project{}'
+
+# Grading workers should be configured to have a hostname of
+# XX@host_machine, where XX is one of the keys in this dictionary.
+# This dictionary then defines the kinds of queues those workers should
+# consume from. For example, 'submission_grader' workers consume from
+# both 'project' and 'fast_project' queues.
+WORKER_PREFIX_TO_QUEUE_TMPLS = {
+    SUBMISSION_WORKER_PREFIX: [SUBMISSION_QUEUE_TMPL, FAST_QUEUE_TMPL],
+    FAST_GRADER_WORKER_PREFIX: [FAST_QUEUE_TMPL],
+    DEFERRED_WORKER_PREFIX: [DEFERRED_QUEUE_TMPL],
+    RERUN_WORKER_PREFIX: [RERUN_QUEUE_TMPL],
+}


### PR DESCRIPTION
- Replaced single 'deferred' and 'rerun' queues with per-project queues to introduce round-robin consumption.
- Added per-project 'fast' queues. Submissions are placed in a fast queue if their estimated worst-case grading time is < 10 min.

Fixes #515 
Fixes #520 