### PR TITLE
Added a None check in serialize_ultimate_submission_results to handle…

### DIFF
--- a/autograder/rest_api/serialize_ultimate_submission_results.py
+++ b/autograder/rest_api/serialize_ultimate_submission_results.py
@@ -64,6 +64,10 @@ def serialize_ultimate_submission_results(ultimate_submissions: Iterable[Submiss
             if username in submission.does_not_count_for:
                 user_ultimate_submission = get_ultimate_submission(
                     group, group.members.get(username=username))
+
+                if user_ultimate_submission is None:
+                    continue
+
                 # NOTE: Do NOT overwrite submission_data
                 user_submission_data = get_submission_data_with_results(
                     SubmissionResultFeedback(


### PR DESCRIPTION
… the case where a user has no submissions that count for them.

Fixes #541 