### PR TITLE
Updated output truncation threshold to be same as max instructor file size

### DIFF
--- a/autograder/core/constants.py
+++ b/autograder/core/constants.py
@@ -7,8 +7,13 @@ MAX_USERNAME_LEN = User._meta.get_field('username').max_length
 
 MAX_CHAR_FIELD_LEN = 255
 
-MAX_OUTPUT_LENGTH = 8 * pow(10, 6)  # 8,000,000 characters
-MAX_PROJECT_FILE_SIZE = 15 * (10 ** 6)  # 15,000,000 bytes
+# The maximum size for an instructor file.
+MAX_INSTRUCTOR_FILE_SIZE = 15 * (10 ** 6)  # 15,000,000 bytes
+
+# Recorded output longer than this value will be truncated.
+# Since instructor files can be used as expected stdout/stderr,
+# this value must be the SAME as MAX_INSTRUCTOR_FILE_SIZE.
+MAX_RECORDED_OUTPUT_LENGTH = MAX_INSTRUCTOR_FILE_SIZE
 
 # For a given project, the name of the directory that
 # user-uploaded project files should be placed in.

--- a/autograder/core/models/ag_test/ag_test_command.py
+++ b/autograder/core/models/ag_test/ag_test_command.py
@@ -193,6 +193,11 @@ class ExpectedReturnCode(enum.Enum):
     nonzero = 'nonzero'
 
 
+# The maximum length of the "expected_stdout_text" and "expected_stderr_text"
+# fields in AGTestCommand.
+MAX_EXPECTED_OUTPUT_TEXT_LENGTH = 8 * pow(10, 6)  # 8,000,000 characters
+
+
 class AGTestCommand(AGCommandBase):
     """
     An AGTestCommand represents a single command to evaluate student code.
@@ -238,7 +243,7 @@ class AGTestCommand(AGCommandBase):
         help_text="Specifies what kind of source this command's stdout should be compared to.")
     expected_stdout_text = models.TextField(
         blank=True,
-        validators=[MaxLengthValidator(constants.MAX_OUTPUT_LENGTH)],
+        validators=[MaxLengthValidator(MAX_EXPECTED_OUTPUT_TEXT_LENGTH)],
         help_text='''A string whose contents should be compared against this command's stdout.
                      This value is used when expected_stdout_source is ExpectedOutputSource.text
                      and is ignored otherwise.''')
@@ -254,7 +259,7 @@ class AGTestCommand(AGCommandBase):
         help_text="Specifies what kind of source this command's stderr should be compared to.")
     expected_stderr_text = models.TextField(
         blank=True,
-        validators=[MaxLengthValidator(constants.MAX_OUTPUT_LENGTH)],
+        validators=[MaxLengthValidator(MAX_EXPECTED_OUTPUT_TEXT_LENGTH)],
         help_text='''A string whose contents should be compared against this command's stderr.
                      This value is used when expected_stderr_source is ExpectedOutputSource.text
                      and is ignored otherwise.''')

--- a/autograder/core/models/project/instructor_file.py
+++ b/autograder/core/models/project/instructor_file.py
@@ -28,10 +28,10 @@ class InstructorFileManager(AutograderModelManager):
         # is created.
         if 'file_obj' in kwargs and 'project' in kwargs:
             file_obj = kwargs['file_obj']
-            if file_obj.size > const.MAX_PROJECT_FILE_SIZE:
+            if file_obj.size > const.MAX_INSTRUCTOR_FILE_SIZE:
                 raise exceptions.ValidationError(
                     {'content': 'Project files cannot be bigger than {} bytes'.format(
-                        const.MAX_PROJECT_FILE_SIZE)})
+                        const.MAX_INSTRUCTOR_FILE_SIZE)})
             project = kwargs['project']
 
             file_exists = utils.find_if(

--- a/autograder/core/tests/test_models/test_ag_test/test_ag_test_command.py
+++ b/autograder/core/tests/test_models/test_ag_test/test_ag_test_command.py
@@ -3,8 +3,9 @@ import copy
 from django.core import exceptions
 
 import autograder.core.models as ag_models
-from autograder.core import constants
 import autograder.utils.testing.model_obj_builders as obj_build
+from autograder.core import constants
+from autograder.core.models.ag_test.ag_test_command import MAX_EXPECTED_OUTPUT_TEXT_LENGTH
 from autograder.utils.testing import UnitTestBase
 
 
@@ -400,7 +401,7 @@ class AGTestCommandMiscTestCase(UnitTestBase):
         self.assertIn('expected_stderr_source', cm.exception.message_dict)
 
     def test_error_expected_output_text_too_large(self):
-        too_much_text = 'A' * (constants.MAX_OUTPUT_LENGTH + 1)
+        too_much_text = 'A' * (MAX_EXPECTED_OUTPUT_TEXT_LENGTH + 1)
         with self.assertRaises(exceptions.ValidationError) as cm:
             ag_models.AGTestCommand.objects.validate_and_create(
                 name=self.name, ag_test_case=self.ag_test, cmd=self.cmd,

--- a/autograder/core/tests/test_models/test_project/test_instructor_file.py
+++ b/autograder/core/tests/test_models/test_project/test_instructor_file.py
@@ -72,7 +72,7 @@ class CreateInstuctorFileTestCase(_SetUp):
             self.assertIn('file_obj', cm.exception.message_dict)
 
     def test_error_file_too_big(self):
-        too_big = SimpleUploadedFile('wee', b'a' * (constants.MAX_PROJECT_FILE_SIZE + 1))
+        too_big = SimpleUploadedFile('wee', b'a' * (constants.MAX_INSTRUCTOR_FILE_SIZE + 1))
         with self.assertRaises(exceptions.ValidationError) as cm:
             InstructorFile.objects.validate_and_create(project=self.project, file_obj=too_big)
 

--- a/autograder/grading_tasks/tasks/utils.py
+++ b/autograder/grading_tasks/tasks/utils.py
@@ -109,8 +109,8 @@ def run_command_from_args(cmd: str,
                                      # max_stack_size=max_stack_size,
                                      max_virtual_memory=max_virtual_memory,
                                      timeout=timeout,
-                                     truncate_stdout=constants.MAX_OUTPUT_LENGTH,
-                                     truncate_stderr=constants.MAX_OUTPUT_LENGTH)
+                                     truncate_stdout=constants.MAX_RECORDED_OUTPUT_LENGTH,
+                                     truncate_stderr=constants.MAX_RECORDED_OUTPUT_LENGTH)
     return run_result
 
 

--- a/autograder/grading_tasks/tests/test_tasks/test_grade_ag_test.py
+++ b/autograder/grading_tasks/tests/test_tasks/test_grade_ag_test.py
@@ -410,8 +410,10 @@ sys.stderr.flush()
         self.assertFalse(res.timed_out)
         self.assertTrue(res.stdout_truncated)
         self.assertTrue(res.stderr_truncated)
-        self.assertEqual(constants.MAX_OUTPUT_LENGTH, os.path.getsize(res.stdout_filename))
-        self.assertEqual(constants.MAX_OUTPUT_LENGTH, os.path.getsize(res.stderr_filename))
+        self.assertEqual(
+            constants.MAX_RECORDED_OUTPUT_LENGTH, os.path.getsize(res.stdout_filename))
+        self.assertEqual(
+            constants.MAX_RECORDED_OUTPUT_LENGTH, os.path.getsize(res.stderr_filename))
 
     def test_program_prints_non_unicode_chars(self, *args):
         cmd = obj_build.make_full_ag_test_command(
@@ -449,8 +451,10 @@ sys.stderr.flush()
         self.assertTrue(res.setup_stdout_truncated)
         self.assertTrue(res.setup_stderr_truncated)
 
-        self.assertEqual(constants.MAX_OUTPUT_LENGTH, os.path.getsize(res.setup_stdout_filename))
-        self.assertEqual(constants.MAX_OUTPUT_LENGTH, os.path.getsize(res.setup_stderr_filename))
+        self.assertEqual(
+            constants.MAX_RECORDED_OUTPUT_LENGTH, os.path.getsize(res.setup_stdout_filename))
+        self.assertEqual(
+            constants.MAX_RECORDED_OUTPUT_LENGTH, os.path.getsize(res.setup_stderr_filename))
 
     def test_setup_print_non_unicode_chars(self, *args):
         self.ag_test_suite.validate_and_update(
@@ -500,16 +504,16 @@ sys.stderr.flush()
             # 'max_num_processes': constants.MAX_PROCESS_LIMIT,
             # 'max_stack_size': constants.MAX_STACK_SIZE_LIMIT,
             'max_virtual_memory': None,
-            'truncate_stdout': constants.MAX_OUTPUT_LENGTH,
-            'truncate_stderr': constants.MAX_OUTPUT_LENGTH,
+            'truncate_stdout': constants.MAX_RECORDED_OUTPUT_LENGTH,
+            'truncate_stderr': constants.MAX_RECORDED_OUTPUT_LENGTH,
         }
         expected_cmd_args = {
             'timeout': time_limit,
             # 'max_num_processes': process_spawn_limit,
             # 'max_stack_size': stack_size_limit,
             'max_virtual_memory': virtual_memory_limit,
-            'truncate_stdout': constants.MAX_OUTPUT_LENGTH,
-            'truncate_stderr': constants.MAX_OUTPUT_LENGTH,
+            'truncate_stdout': constants.MAX_RECORDED_OUTPUT_LENGTH,
+            'truncate_stderr': constants.MAX_RECORDED_OUTPUT_LENGTH,
         }
         run_command_mock.assert_has_calls([
             mock.call(['bash', '-c', self.ag_test_suite.setup_suite_cmd],
@@ -547,8 +551,8 @@ sys.stderr.flush()
         expected_cmd_args = {
             'timeout': time_limit,
             'max_virtual_memory': None,
-            'truncate_stdout': constants.MAX_OUTPUT_LENGTH,
-            'truncate_stderr': constants.MAX_OUTPUT_LENGTH,
+            'truncate_stdout': constants.MAX_RECORDED_OUTPUT_LENGTH,
+            'truncate_stderr': constants.MAX_RECORDED_OUTPUT_LENGTH,
         }
         run_command_mock.assert_has_calls([
             mock.call(['bash', '-c', cmd.cmd], stdin=None, as_root=False, **expected_cmd_args),

--- a/autograder/grading_tasks/tests/test_tasks/test_grade_student_test_suite/test_grade_student_test_suite.py
+++ b/autograder/grading_tasks/tests/test_tasks/test_grade_student_test_suite/test_grade_student_test_suite.py
@@ -417,8 +417,8 @@ class StudentTestCaseGradingEdgeCaseTestCase(UnitTestBase):
         expected_cmd_args = {
             'timeout': time_limit,
             'max_virtual_memory': None,
-            'truncate_stdout': constants.MAX_OUTPUT_LENGTH,
-            'truncate_stderr': constants.MAX_OUTPUT_LENGTH,
+            'truncate_stdout': constants.MAX_RECORDED_OUTPUT_LENGTH,
+            'truncate_stderr': constants.MAX_RECORDED_OUTPUT_LENGTH,
         }
         run_command_mock.assert_has_calls([
             mock.call(['bash', '-c', 'true'], stdin=None, as_root=False, **expected_cmd_args),

--- a/autograder/rest_api/tests/test_views/test_project_views/test_instructor_file_views.py
+++ b/autograder/rest_api/tests/test_views/test_project_views/test_instructor_file_views.py
@@ -91,7 +91,7 @@ class CreateInstructorFileTestCase(AGViewTestBase):
         self.assertEqual(0, self.project.instructor_files.count())
 
     def test_invalid_create_too_large_uploaded_file(self):
-        too_big_file = SimpleUploadedFile('spam', b'a' * (constants.MAX_PROJECT_FILE_SIZE + 1))
+        too_big_file = SimpleUploadedFile('spam', b'a' * (constants.MAX_INSTRUCTOR_FILE_SIZE + 1))
         self.assertEqual(0, self.project.instructor_files.count())
         self.client.force_authenticate(obj_build.make_admin_user(self.course))
         response = self.client.post(
@@ -271,7 +271,7 @@ class UpdateUploadedFileContentTestCase(_DetailViewTestSetup):
     def test_error_update_content_too_large(self):
         self.client.force_authenticate(self.admin)
         too_big_updated_file = SimpleUploadedFile(
-            self.file_.name, b'a' * (constants.MAX_PROJECT_FILE_SIZE + 1))
+            self.file_.name, b'a' * (constants.MAX_INSTRUCTOR_FILE_SIZE + 1))
 
         response = self.client.put(
             self.url, {'file_obj': too_big_updated_file}, format='multipart')

--- a/autograder/rest_api/views/project_views/instructor_file_views.py
+++ b/autograder/rest_api/views/project_views/instructor_file_views.py
@@ -162,11 +162,11 @@ class InstructorFileContentView(AGModelAPIView):
         uploaded_file = self.get_object()
         uploaded_file.save(update_fields=['last_modified'])
 
-        if self.request.data['file_obj'].size > constants.MAX_PROJECT_FILE_SIZE:
+        if self.request.data['file_obj'].size > constants.MAX_INSTRUCTOR_FILE_SIZE:
             return response.Response(
                 {
                     'content': 'Project files cannot be bigger than {} bytes'.format(
-                        constants.MAX_PROJECT_FILE_SIZE)
+                        constants.MAX_INSTRUCTOR_FILE_SIZE)
                 },
                 status=status.HTTP_400_BAD_REQUEST)
         with open(uploaded_file.abspath, 'wb') as f:


### PR DESCRIPTION
Also moved MAX_OUTPUT_LENGTH to ag_test_command.py and renamed it.
Introduced MAX_RECORDED_OUTPUT_LENGTH constant that is an alias for MAX_INSTRUCTOR_FILE_SIZE.

Fixes #494 