### PR TITLE
Downgraded django to 2.2.12.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 autograder-sandbox==4.0.2
 celery==4.4.2
-Django==3.0.5
+Django==2.2.12
 django-extensions==1.9.8
 django-redis==4.11.0
 django-timezone-field==4.0


### PR DESCRIPTION
In ag-client-typescript, the instance of autograder-server that we use for testing has been experiencing sporadic
database errors (most common is 'connection already closed'). These errors never occured prior to using django 3.