### PR TITLE
Chang hardcoded "localhost" to settings.SANDBOX_IMAGE_REGISTRY_HOST…

### DIFF
--- a/autograder/core/tests/test_tasks.py
+++ b/autograder/core/tests/test_tasks.py
@@ -82,7 +82,8 @@ class BuildSandboxDockerImageTestCase(UnitTestBase):
                 course=image.course,
             )
         self.assertIn(
-            f'localhost:{settings.SANDBOX_IMAGE_REGISTRY_PORT}/build{task.pk}_result',
+            f'{settings.SANDBOX_IMAGE_REGISTRY_HOST}:{settings.SANDBOX_IMAGE_REGISTRY_PORT}'
+            f'/build{task.pk}_result',
             image.tag
         )
 


### PR DESCRIPTION
… (which defaults to 127.0.0.1)

This fixes some test regressions.