### PR TITLE
Add an 'all_bug_names' property to MutationTestSuiteResult.Feedback…

### DIFF
--- a/autograder/core/models/mutation_test_suite/mutation_test_suite.py
+++ b/autograder/core/models/mutation_test_suite/mutation_test_suite.py
@@ -15,6 +15,7 @@ class BugsExposedFeedbackLevel(core_ut.OrderedEnum):
     no_feedback = 'no_feedback'
     num_bugs_exposed = 'num_bugs_exposed'
     exposed_bug_names = 'exposed_bug_names'
+    all_bug_names = 'all_bug_names'
 
 
 class MutationTestSuiteFeedbackConfig(DictSerializableMixin):

--- a/autograder/core/models/mutation_test_suite/mutation_test_suite_result.py
+++ b/autograder/core/models/mutation_test_suite/mutation_test_suite_result.py
@@ -288,10 +288,17 @@ class MutationTestSuiteResult(AutograderModel):
 
         @property
         def bugs_exposed(self) -> Optional[List[str]]:
-            if self._fdbk.bugs_exposed_fdbk_level != BugsExposedFeedbackLevel.exposed_bug_names:
+            if self._fdbk.bugs_exposed_fdbk_level < BugsExposedFeedbackLevel.exposed_bug_names:
                 return None
 
             return self._mutation_test_suite_result.bugs_exposed
+
+        @property
+        def all_bug_names(self) -> Optional[List[str]]:
+            if self._fdbk.bugs_exposed_fdbk_level < BugsExposedFeedbackLevel.all_bug_names:
+                return None
+
+            return self._mutation_test_suite.buggy_impl_names
 
         @property
         def validity_check_stdout(self) -> Optional[BinaryIO]:
@@ -384,6 +391,7 @@ class MutationTestSuiteResult(AutograderModel):
             'timed_out_tests',
             'num_bugs_exposed',
             'bugs_exposed',
+            'all_bug_names',
             'total_points',
             'total_points_possible',
         )

--- a/autograder/core/tests/test_models/test_mutation_test_suite/test_mutation_test_suite_result.py
+++ b/autograder/core/tests/test_models/test_mutation_test_suite/test_mutation_test_suite_result.py
@@ -544,6 +544,7 @@ class MutationTestSuiteResultFeedbackTestCase(UnitTestBase):
             MutationTestSuitePreLoader(self.project))
         self.assertIsNone(fdbk.num_bugs_exposed)
         self.assertIsNone(fdbk.bugs_exposed)
+        self.assertIsNone(fdbk.all_bug_names)
         self.assertEqual(0, fdbk.total_points)
         self.assertEqual(0, fdbk.total_points_possible)
 
@@ -560,6 +561,7 @@ class MutationTestSuiteResultFeedbackTestCase(UnitTestBase):
             MutationTestSuitePreLoader(self.project))
         self.assertEqual(len(self.bugs_exposed), fdbk.num_bugs_exposed)
         self.assertIsNone(fdbk.bugs_exposed)
+        self.assertIsNone(fdbk.all_bug_names)
         self.assertEqual(self.points_awarded, fdbk.total_points)
         self.assertEqual(self.points_possible, fdbk.total_points_possible)
 
@@ -576,6 +578,25 @@ class MutationTestSuiteResultFeedbackTestCase(UnitTestBase):
             MutationTestSuitePreLoader(self.project))
         self.assertEqual(len(self.bugs_exposed), fdbk.num_bugs_exposed)
         self.assertSequenceEqual(self.bugs_exposed, fdbk.bugs_exposed)
+        self.assertIsNone(fdbk.all_bug_names)
+        self.assertEqual(self.points_awarded, fdbk.total_points)
+        self.assertEqual(self.points_possible, fdbk.total_points_possible)
+
+    def test_show_all_bug_names(self) -> None:
+        self.mutation_suite.validate_and_update(
+            normal_fdbk_config={
+                'show_points': True,
+                'bugs_exposed_fdbk_level': ag_models.BugsExposedFeedbackLevel.all_bug_names
+            }
+        )
+
+        fdbk = self.result.get_fdbk(
+            ag_models.FeedbackCategory.normal,
+            MutationTestSuitePreLoader(self.project))
+        self.assertEqual(len(self.bugs_exposed), fdbk.num_bugs_exposed)
+        self.assertSequenceEqual(self.bugs_exposed, fdbk.bugs_exposed)
+        self.assertSequenceEqual(self.bug_names, fdbk.all_bug_names)
+
         self.assertEqual(self.points_awarded, fdbk.total_points)
         self.assertEqual(self.points_possible, fdbk.total_points_possible)
 
@@ -631,6 +652,7 @@ class MutationTestSuiteResultFeedbackTestCase(UnitTestBase):
             'timed_out_tests',
             'num_bugs_exposed',
             'bugs_exposed',
+            'all_bug_names',
             'total_points',
             'total_points_possible',
         ]

--- a/schema/schema.yml
+++ b/schema/schema.yml
@@ -8096,6 +8096,7 @@ components:
       - no_feedback
       - num_bugs_exposed
       - exposed_bug_names
+      - all_bug_names
     MutationTestSuiteResultFeedback:
       type: object
       properties:
@@ -8155,6 +8156,11 @@ components:
           nullable: true
           type: integer
         bugs_exposed:
+          description: ''
+          nullable: true
+          type: array
+          items: *id062
+        all_bug_names:
           description: ''
           nullable: true
           type: array


### PR DESCRIPTION
…Calculator and 'all_bug_names' field to BugsExposedFeedbackLevel.

When this new feedback option is selected, the user will see a list of all buggy impl names in addition to a list of bugs exposed.

Fixes #375