### PR TITLE
Refactored SubmissionResultFeedback.mutation_test_suite_results to re…

### DIFF
--- a/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
@@ -117,8 +117,8 @@ class SubmissionFeedbackTestCase(UnitTestBase):
         self.assertSequenceEqual([self.ag_suite_result1.pk, self.ag_suite_result2.pk],
                                  [res.pk for res in fdbk.ag_test_suite_results])
 
-        self.assertSequenceEqual([self.mutation_suite_result1, self.mutation_suite_result2],
-                                 fdbk.mutation_test_suite_results)
+        self.assertSequenceEqual([self.mutation_suite_result1.pk, self.mutation_suite_result2.pk],
+                                 [res.pk for res in fdbk.mutation_test_suite_results])
 
     def test_ag_suite_result_ordering(self):
         for i in range(2):
@@ -137,14 +137,14 @@ class SubmissionFeedbackTestCase(UnitTestBase):
             self.project.set_mutationtestsuite_order(
                 [self.mutation_suite2.pk, self.mutation_suite1.pk])
             fdbk = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
-            self.assertSequenceEqual([self.mutation_suite_result2, self.mutation_suite_result1],
-                                     fdbk.mutation_test_suite_results)
+            self.assertSequenceEqual([self.mutation_suite_result2.pk, self.mutation_suite_result1.pk],
+                                     [res.pk for res in fdbk.mutation_test_suite_results])
 
             self.project.set_mutationtestsuite_order(
                 [self.mutation_suite1.pk, self.mutation_suite2.pk])
             fdbk = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
-            self.assertSequenceEqual([self.mutation_suite_result1, self.mutation_suite_result2],
-                                     fdbk.mutation_test_suite_results)
+            self.assertSequenceEqual([self.mutation_suite_result1.pk, self.mutation_suite_result2.pk],
+                                     [res.pk for res in fdbk.mutation_test_suite_results])
 
     def test_max_fdbk_some_incorrect(self):
         # Make something incorrect, re-check total points and total points
@@ -214,8 +214,8 @@ class SubmissionFeedbackTestCase(UnitTestBase):
             'ag_test_suite_results'][0]['ag_test_case_results'][0]['ag_test_command_results']
         self.assertSequenceEqual([], actual_cmd_results)
 
-        self.assertSequenceEqual([self.mutation_suite_result1, self.mutation_suite_result2],
-                                 fdbk.mutation_test_suite_results)
+        self.assertSequenceEqual([self.mutation_suite_result1.pk, self.mutation_suite_result2.pk],
+                                 [res.pk for res in fdbk.mutation_test_suite_results])
 
     def test_past_limit_fdbk(self):
         self.ag_test_cmd2.validate_and_update(
@@ -264,7 +264,8 @@ class SubmissionFeedbackTestCase(UnitTestBase):
             'ag_test_suite_results'][1]['ag_test_case_results'][0]['ag_test_command_results']
         self.assertSequenceEqual([], actual_cmd_results)
 
-        self.assertSequenceEqual([self.mutation_suite_result1], fdbk.mutation_test_suite_results)
+        self.assertSequenceEqual([self.mutation_suite_result1.pk],
+                                 [res.pk for res in fdbk.mutation_test_suite_results])
 
     def test_ultimate_fdbk(self):
         self.ag_test_cmd1.validate_and_update(ultimate_submission_fdbk_config={'visible': False})
@@ -282,7 +283,10 @@ class SubmissionFeedbackTestCase(UnitTestBase):
             'ag_test_suite_results'][0]['ag_test_case_results'][0]['ag_test_command_results']
         self.assertSequenceEqual([], actual_cmd_results)
 
-        self.assertSequenceEqual([self.mutation_suite_result2], fdbk.mutation_test_suite_results)
+        self.assertSequenceEqual(
+            [self.mutation_suite_result2.pk],
+            [res.pk for res in fdbk.mutation_test_suite_results]
+        )
 
     def test_individual_suite_result_order(self):
         self.project.set_agtestsuite_order([self.ag_test_suite2.pk, self.ag_test_suite1.pk])
@@ -299,16 +303,17 @@ class SubmissionFeedbackTestCase(UnitTestBase):
              get_suite_fdbk(self.ag_suite_result1, ag_models.FeedbackCategory.max).to_dict()],
             fdbk.to_dict()['ag_test_suite_results'])
 
-        self.assertSequenceEqual([self.mutation_suite_result2, self.mutation_suite_result1],
-                                 fdbk.mutation_test_suite_results)
-        self.assertSequenceEqual(
-            [self.mutation_suite_result2.get_fdbk(
+        expected = [
+            self.mutation_suite_result2.get_fdbk(
                 ag_models.FeedbackCategory.max,
-                MutationTestSuitePreLoader(self.project)).to_dict(),
-             self.mutation_suite_result1.get_fdbk(
-                 ag_models.FeedbackCategory.max,
-                 MutationTestSuitePreLoader(self.project)).to_dict()],
-            fdbk.to_dict()['mutation_test_suite_results'])
+                MutationTestSuitePreLoader(self.project)
+            ).to_dict(),
+            self.mutation_suite_result1.get_fdbk(
+                ag_models.FeedbackCategory.max,
+                MutationTestSuitePreLoader(self.project)
+            ).to_dict()
+        ]
+        self.assertSequenceEqual(expected, fdbk.to_dict()['mutation_test_suite_results'])
 
     def test_some_ag_and_mutation_test_suites_not_visible(self):
         self.ag_test_suite2.validate_and_update(
@@ -329,12 +334,13 @@ class SubmissionFeedbackTestCase(UnitTestBase):
                             ag_models.FeedbackCategory.ultimate_submission).to_dict()],
             fdbk.to_dict()['ag_test_suite_results'])
 
-        self.assertSequenceEqual([self.mutation_suite_result1], fdbk.mutation_test_suite_results)
-        self.assertSequenceEqual(
-            [self.mutation_suite_result1.get_fdbk(
+        expected = [
+            self.mutation_suite_result1.get_fdbk(
                 ag_models.FeedbackCategory.ultimate_submission,
-                MutationTestSuitePreLoader(self.project)).to_dict()],
-            fdbk.to_dict()['mutation_test_suite_results'])
+                MutationTestSuitePreLoader(self.project)
+            ).to_dict()
+        ]
+        self.assertSequenceEqual(expected, fdbk.to_dict()['mutation_test_suite_results'])
 
     def test_fdbk_to_dict(self):
         expected = {

--- a/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
+++ b/autograder/core/tests/test_submission_feedback/test_submission_feedback.py
@@ -137,14 +137,18 @@ class SubmissionFeedbackTestCase(UnitTestBase):
             self.project.set_mutationtestsuite_order(
                 [self.mutation_suite2.pk, self.mutation_suite1.pk])
             fdbk = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
-            self.assertSequenceEqual([self.mutation_suite_result2.pk, self.mutation_suite_result1.pk],
-                                     [res.pk for res in fdbk.mutation_test_suite_results])
+            self.assertSequenceEqual(
+                [self.mutation_suite_result2.pk, self.mutation_suite_result1.pk],
+                [res.pk for res in fdbk.mutation_test_suite_results]
+            )
 
             self.project.set_mutationtestsuite_order(
                 [self.mutation_suite1.pk, self.mutation_suite2.pk])
             fdbk = get_submission_fdbk(self.submission, ag_models.FeedbackCategory.max)
-            self.assertSequenceEqual([self.mutation_suite_result1.pk, self.mutation_suite_result2.pk],
-                                     [res.pk for res in fdbk.mutation_test_suite_results])
+            self.assertSequenceEqual(
+                [self.mutation_suite_result1.pk, self.mutation_suite_result2.pk],
+                [res.pk for res in fdbk.mutation_test_suite_results]
+            )
 
     def test_max_fdbk_some_incorrect(self):
         # Make something incorrect, re-check total points and total points

--- a/autograder/rest_api/schema.py
+++ b/autograder/rest_api/schema.py
@@ -196,9 +196,6 @@ API_OBJ_TYPE_NAMES: Dict[APIClassType, str] = {
     ag_models.MutationTestSuite: ag_models.MutationTestSuite.__name__,
     ag_models.MutationTestSuiteFeedbackConfig: ag_models.MutationTestSuiteFeedbackConfig.__name__,
     ag_models.BugsExposedFeedbackLevel: ag_models.BugsExposedFeedbackLevel.__name__,
-    # Hack: SubmissionResultFeedback.mutation_test_suite_results returns
-    # List[MutationTestSuiteResult], but it gets serialized to MutationTestSuiteResultFeedback
-    ag_models.MutationTestSuiteResult: 'MutationTestSuiteResultFeedback',
     ag_models.MutationTestSuiteResult.FeedbackCalculator: 'MutationTestSuiteResultFeedback',
 
     ag_models.RerunSubmissionsTask: ag_models.RerunSubmissionsTask.__name__,

--- a/autograder/rest_api/tests/test_tasks/test_project_downloads.py
+++ b/autograder/rest_api/tests/test_tasks/test_project_downloads.py
@@ -976,9 +976,7 @@ class DownloadAllSubmissionGradesTestCase(UnitTestBase):
                 for case_fdbk in suite_fdbk.ag_test_case_results:
                     values.append(str(case_fdbk.total_points))
 
-            for suite_result in fdbk.mutation_test_suite_results:
-                suite_fdbk = suite_result.get_fdbk(
-                    ag_models.FeedbackCategory.max, MutationTestSuitePreLoader(self.project))
+            for suite_fdbk in fdbk.mutation_test_suite_results:
                 values += [str(suite_fdbk.total_points), str(suite_fdbk.total_points_possible)]
 
             self.assertEqual(len(expected_headers), len(values))

--- a/autograder/rest_api/views/submission_views/submission_result_views.py
+++ b/autograder/rest_api/views/submission_views/submission_result_views.py
@@ -593,16 +593,15 @@ class MutationTestSuiteOutputSizeView(SubmissionResultsViewBase):
         if result is None:
             return response.Response(None)
 
-        fdbk = result.get_fdbk(fdbk_category, submission_fdbk.mutation_test_suite_preloader)
         return response.Response({
-            'setup_stdout_size': fdbk.get_setup_stdout_size(),
-            'setup_stderr_size': fdbk.get_setup_stderr_size(),
-            'get_student_test_names_stdout_size': fdbk.get_student_test_names_stdout_size(),
-            'get_student_test_names_stderr_size': fdbk.get_student_test_names_stderr_size(),
-            'validity_check_stdout_size': fdbk.get_validity_check_stdout_size(),
-            'validity_check_stderr_size': fdbk.get_validity_check_stderr_size(),
-            'grade_buggy_impls_stdout_size': fdbk.get_grade_buggy_impls_stdout_size(),
-            'grade_buggy_impls_stderr_size': fdbk.get_grade_buggy_impls_stderr_size(),
+            'setup_stdout_size': result.get_setup_stdout_size(),
+            'setup_stderr_size': result.get_setup_stderr_size(),
+            'get_student_test_names_stdout_size': result.get_student_test_names_stdout_size(),
+            'get_student_test_names_stderr_size': result.get_student_test_names_stderr_size(),
+            'validity_check_stdout_size': result.get_validity_check_stdout_size(),
+            'validity_check_stderr_size': result.get_validity_check_stderr_size(),
+            'grade_buggy_impls_stdout_size': result.get_grade_buggy_impls_stdout_size(),
+            'grade_buggy_impls_stderr_size': result.get_grade_buggy_impls_stderr_size(),
         })
 
 
@@ -619,16 +618,17 @@ def _get_mutation_suite_result_output_field(
     if result is None:
         return response.Response(None)
 
-    output_stream = get_output_fn(
-        result.get_fdbk(fdbk_category, submission_fdbk.mutation_test_suite_preloader))
+    output_stream = get_output_fn(result)
     if output_stream is None:
         return response.Response(None)
 
     return FileResponse(output_stream)
 
 
-def _find_mutation_suite_result(submission_fdbk: SubmissionResultFeedback,
-                                mutation_suite_result_pk: int):
+def _find_mutation_suite_result(
+    submission_fdbk: SubmissionResultFeedback,
+    mutation_suite_result_pk: int
+) -> Optional[ag_models.MutationTestSuiteResult.FeedbackCalculator]:
     """
     :raises: Http404 exception if a mutation suite result with the given primary
              key doesn't exist in the database.


### PR DESCRIPTION
…turn a list on MutationTestSuiteResult.FeedbackCalculator.

The implementations of .ag_test_suite_results and .mutation_test_suite_results are now more consistent.
This also lets us remove a hack in the API_OBJ_TYPE_NAMES schema mapping.

Fixes #528 (For real this time)