### PR TITLE
599 oauth providers

### DIFF
--- a/autograder/rest_api/auth.py
+++ b/autograder/rest_api/auth.py
@@ -15,10 +15,13 @@ GOOGLE_API_SCOPES = [
     'profile',
 ]
 
+# For details about the Microsoft Identity Platform and OpenID see
+# https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#openid-connect-scopes
 AZURE_API_SCOPES = [
     'openid',
     'email',
     'profile',
+    'offline_access',  # required for refresh token
 ]
 
 

--- a/autograder/rest_api/views/oauth2callback.py
+++ b/autograder/rest_api/views/oauth2callback.py
@@ -95,7 +95,7 @@ class GoogleOAuth2CallbackHandler(OAuth2CallbackHandler):
                 email = email['value']
             except KeyError:
                 print('WARNING: emailAddress not found. Using alternate API')
-                em_url = ('https://www.googleapis.com/userinfo/v2/me?fields=email')
+                em_url = 'https://www.googleapis.com/userinfo/v2/me?fields=email'
                 em_response, em_content = http.request(em_url, 'GET')
                 em_user_info = json.loads(em_content)
                 email = em_user_info['email']

--- a/autograder/rest_api/views/oauth2callback.py
+++ b/autograder/rest_api/views/oauth2callback.py
@@ -141,7 +141,8 @@ class AzureOAuth2CallbackHandler(OAuth2CallbackHandler):
 
             http = credentials.authorize(httplib2.Http())
 
-            # Based upon https://docs.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0
+            # Based upon:
+            # https://docs.microsoft.com/en-us/graph/api/resources/users?view=graph-rest-1.0
 
             url = 'https://graph.microsoft.com/v1.0/me'
             response, content = http.request(url, 'GET')

--- a/autograder/rest_api/views/oauth2callback.py
+++ b/autograder/rest_api/views/oauth2callback.py
@@ -12,6 +12,7 @@ from oauth2client import client
 import httplib2
 from rest_framework.authtoken.models import Token
 
+from autograder.rest_api.auth import AZURE_API_SCOPES
 from autograder.rest_api.auth import GOOGLE_API_SCOPES
 
 from autograder import utils
@@ -136,7 +137,7 @@ class AzureOAuth2CallbackHandler(OAuth2CallbackHandler):
         content = None
         try:
             credentials = client.credentials_from_clientsecrets_and_code(
-                settings.OAUTH2_SECRETS_PATH, GOOGLE_API_SCOPES, request.GET,
+                settings.OAUTH2_SECRETS_PATH, AZURE_API_SCOPES, request.GET,
                 redirect_uri=self._state['redirect_uri'])
 
             http = credentials.authorize(httplib2.Http())


### PR DESCRIPTION
@james-perretta This was pretty easy. Basically just needed a different Microsoft specific URL and different field names. I more I less used your code but changed the logic a little as the fields are guaranteed to be present but might be None.

The only point that maybe is not great, is that I am using the GOOGLE_API_SCOPES for Azure too. The scopes in the list are the correct ones, but if they change in the future then this might break this handler. I thought I would leave this for now as I think changes to them are very unlikely and the risk is low.