### PR TITLE
Pulled code that starts submission rerun task out of transaction block.

### DIFF
--- a/autograder/grading_tasks/tasks/rerun_submission.py
+++ b/autograder/grading_tasks/tasks/rerun_submission.py
@@ -57,7 +57,7 @@ class SubmissionRerunner:
 
     def rerun_submission(self) -> None:
         try:
-            self.load_submission()
+            self.load_data()
             self.rerun_suites()
             self.mark_as_finished()
         except RerunCancelled:
@@ -68,11 +68,9 @@ class SubmissionRerunner:
             self.record_submission_grading_error(traceback.format_exc())
 
     @retry_should_recover
-    def load_submission(self):
+    def load_data(self):
         """
-        Loads the submission self.submission to the loaded submission
-        and self.project to the project it belongs to.
-        This override does NOT modify the submission in the database.
+        Loads the rerun task, submission, group, and project requested.
         """
         with transaction.atomic():
             self._rerun_task = ag_models.RerunSubmissionsTask.objects.get(pk=self._rerun_task_pk)

--- a/autograder/rest_api/views/rerun_submissions_task_views.py
+++ b/autograder/rest_api/views/rerun_submissions_task_views.py
@@ -55,14 +55,14 @@ class RerunSubmissionsTaskListCreateView(NestedModelView):
                     ]
                 )
 
-            signatures = [
-                rerun_submission.s(
-                    submission.pk, rerun_task.pk
-                ).set(queue=settings.RERUN_QUEUE_TMPL.format(project.pk))
-                for submission in submissions
-            ]
-            from autograder.celery import app
-            celery.group(signatures, app=app).apply_async()
+        signatures = [
+            rerun_submission.s(
+                submission.pk, rerun_task.pk
+            ).set(queue=settings.RERUN_QUEUE_TMPL.format(project.pk))
+            for submission in submissions
+        ]
+        from autograder.celery import app
+        celery.group(signatures, app=app).apply_async()
 
         return response.Response(rerun_task.to_dict(), status=status.HTTP_201_CREATED)
 

--- a/autograder/rest_api/views/sandbox_docker_image_views.py
+++ b/autograder/rest_api/views/sandbox_docker_image_views.py
@@ -135,9 +135,6 @@ class ListCreateSandboxDockerImageForCourseView(ag_views.NestedModelView):
 
     @convert_django_validation_error
     def post(self, request, *args, **kwargs):
-        """
-        List all sandbox images for the specified course.
-        """
         with transaction.atomic():
             course = self.get_object()
             build_task = ag_models.BuildSandboxDockerImageTask.objects.validate_and_create(

--- a/schema/schema.yml
+++ b/schema/schema.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Autograder.io API
-  version: 4.1.3
+  version: 4.2.0
 paths:
   /api/users/current/:
     get:
@@ -3280,7 +3280,7 @@ paths:
       - sandbox_docker_images
     post:
       operationId: createSandboxDockerImageForCourse
-      description: List all sandbox images for the specified course.
+      description: ''
       parameters:
       - name: id
         in: path


### PR DESCRIPTION
Note that since we have a cancel button for reruns, it's not the end of the world if something goes wrong starting the task.