### PR TITLE
Add ObjectDoesNotExist to RERAISE_IMMEDIATELY for retry decorators.

### DIFF
--- a/autograder/utils/retry.py
+++ b/autograder/utils/retry.py
@@ -3,7 +3,7 @@ import traceback
 
 from django import db
 from django.conf import settings
-from django.db import transaction
+from django.core.exceptions import ObjectDoesNotExist
 
 from autograder.grading_tasks.tasks.exceptions import StopGrading, TestDeleted
 
@@ -107,6 +107,7 @@ RERAISE_IMMEDIATELY = (
     db.IntegrityError,
     StopGrading,
     TestDeleted,
+    ObjectDoesNotExist,  # raised by QuerySet.get()
     MaxRetriesExceeded,  # We don't want nested retry loops
 )
 


### PR DESCRIPTION
In submission grading, we typically don't expect for objects we're trying to load to not exist, making this a fatal error that should stop the task. If there end up being cases where we do expect such an error, we can catch it and handle it appropriately.