### PR TITLE
Created `has_autograded_submissions` to detect whether student group has at least one non-rejected AG submission

### DIFF
--- a/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
+++ b/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
@@ -726,6 +726,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
                 'finished_grading': hg_result.finished_grading
             }
             data['member_names'].sort()
+            data['has_autograded_submissions'] = True
             expected_data.append(data)
 
         # Groups that don't have a handgrading result
@@ -733,6 +734,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
             data = groups[i].to_dict()
             data['member_names'].sort()
             data['handgrading_result'] = None
+            data['has_autograded_submissions'] = False
             expected_data.append(data)
 
         expected_data.sort(key=lambda group: group['member_names'][0])

--- a/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
+++ b/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
@@ -746,7 +746,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
                 'finished_grading': hg_result.finished_grading
             }
             data['member_names'].sort()
-            data['has_autograded_submissions'] = True
+            data['has_handgradeable_submission'] = True
             expected_data.append(data)
         
         for i in range(num_results, num_results + num_groups_only_reject):
@@ -755,7 +755,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
             data = group.to_dict()
             data['member_names'].sort()
             data['handgrading_result'] = None
-            data['has_autograded_submissions'] = False
+            data['has_handgradeable_submission'] = False
             expected_data.append(data)
         
         # Groups that don't have a handgrading result
@@ -763,7 +763,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
             data = groups[i].to_dict()
             data['member_names'].sort()
             data['handgrading_result'] = None
-            data['has_autograded_submissions'] = False
+            data['has_handgradeable_submission'] = False
             expected_data.append(data)
 
         expected_data.sort(key=lambda group: group['member_names'][0])

--- a/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
+++ b/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
@@ -631,9 +631,74 @@ class _GroupHGDataConfig:
         if self.submission_status != ag_models.Submission.GradingStatus.finished_grading:
             # If the submission does not have a finished_grading status, it must not
             # have a handgrading result
-            assert not self.has_handgrading_result,\
+            assert not self.has_handgrading_result, \
                 ('Submissions with a status other than'
                  ' "finished_grading" must not have a handgrading result')
+
+    def create_submission(self, group: ag_models.Group) -> ag_models.Submission | None:
+        """
+        Create a submission based on the configuration.
+        If submission_status is None, return None.
+        """
+        if self.submission_status is None:
+            return None
+        return obj_build.make_submission(group=group, status=self.submission_status)
+
+    @staticmethod
+    def format_group_data(group, handgrading_result: dict | None,
+                          has_handgradeable_submission: bool) -> dict:
+        """Format the group data for comparison with the response data."""
+        data = group.to_dict()
+        data['handgrading_result'] = handgrading_result
+        data['member_names'].sort()
+        data['has_handgradeable_submission'] = has_handgradeable_submission
+        return data
+
+    def generate_expected_data(self, group: ag_models.Group,
+                               rubric: hg_models.HandgradingRubric) -> dict:
+        """Generate the expected data base on submission status and handgrading result status."""
+        submission = self.create_submission(group)
+        match self.has_handgrading_result, self.submission_status:
+            # A finished_grading submission with a handgrading result
+            case True, _:
+                return self.generate_expected_data_with_handgrading_result(
+                    group, submission, rubric)
+            # A finished_grading submission without a handgrading result
+            # (has_handgradeable_submission would still be true in this case)
+            case False, ag_models.Submission.GradingStatus.finished_grading:
+                return self.format_group_data(group,
+                                              handgrading_result=None,
+                                              has_handgradeable_submission=True)
+            # A submission with any status other than
+            # finished_grading (and consequently no handgrading result either).
+            # has_handgradeable_submission would be false in this case.
+            case _:
+                return self.format_group_data(group,
+                                              handgrading_result=None,
+                                              has_handgradeable_submission=False)
+
+    def generate_expected_data_with_handgrading_result(
+            self, group: ag_models.Group, submission: ag_models.Submission,
+            rubric: hg_models.HandgradingRubric) -> dict:
+        """Generate the expected data for a group with a handgrading result."""
+        hg_result = hg_models.HandgradingResult.objects.validate_and_create(
+            submission=submission,
+            group=group,
+            handgrading_rubric=rubric
+        )
+        handgrading_data = {
+            'total_points': hg_result.total_points,
+            'total_points_possible': hg_result.total_points_possible,
+            'finished_grading': hg_result.finished_grading
+        }
+        match self.submission_status:
+            # Is handgradable when the submission has a finished grading status
+            case ag_models.Submission.GradingStatus.finished_grading:
+                return self.format_group_data(
+                    group, handgrading_data, has_handgradeable_submission=True)
+            case _:
+                return self.format_group_data(
+                    group, handgrading_data, has_handgradeable_submission=False)
 
 
 class ListHandgradingResultsViewTestCase(UnitTestBase):
@@ -714,7 +779,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
 
     def test_get_paginated_results_some_groups_have_no_result(self):
         self.do_handgrading_results_test(
-            self.handgrader, num_groups=4, submission_configs=[
+            self.handgrader, num_groups=4, group_handgrading_data_configs=[
                 _GroupHGDataConfig()] * 2 + [_GroupHGDataConfig(has_handgrading_result=False)] * 2)
 
     def test_non_staff_non_handgrader_get_handgrading_results_permission_denied(self):
@@ -727,7 +792,7 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
         self.do_handgrading_results_test(
             self.handgrader,
             num_groups=3,
-            submission_configs=[
+            group_handgrading_data_configs=[
                 _GroupHGDataConfig()] + 2 * [
                 _GroupHGDataConfig(
                     submission_status=Submission.GradingStatus.rejected,
@@ -737,61 +802,28 @@ class ListHandgradingResultsViewTestCase(UnitTestBase):
         self.do_handgrading_results_test(
             self.staff,
             num_groups=3,
-            submission_configs=[
+            group_handgrading_data_configs=[
                 _GroupHGDataConfig()] + [
                 _GroupHGDataConfig(
                     submission_status=Submission.GradingStatus.rejected,
                     has_handgrading_result=False)] * 2)
 
     def do_handgrading_results_test(self, user: User, *, num_groups: int = None,
-                                    submission_configs:
+                                    group_handgrading_data_configs:
                                     list[_GroupHGDataConfig] | None = None,
                                     page_size: int = None, page_num: int = None):
         """Perform the test for the handgrading results view."""
-        if submission_configs is None:
+        if group_handgrading_data_configs is None:
             # default initialization of submission_configs to all finished grading submissions
-            submission_configs = [_GroupHGDataConfig()] * num_groups
+            group_handgrading_data_configs = [_GroupHGDataConfig()] * num_groups
         else:
-            assert len(submission_configs) == num_groups
-
-        # ensure that finished grading submissions are sorted before rejected submissions
-        submission_configs.sort(
-            key=lambda config:
-            config.submission_status is Submission.GradingStatus.finished_grading)
+            assert len(group_handgrading_data_configs) == num_groups
 
         groups = [obj_build.make_group(3, project=self.project) for _ in range(num_groups)]
 
-        def gen_exp_data(group: ag_models.Group, config: _GroupHGDataConfig):
-            """Generate the expected data for a group based on the configuration."""
-
-            submission = None
-            if config.submission_status is not None:
-                submission = obj_build.make_submission(
-                    group=group, status=config.submission_status)
-
-            if config.has_handgrading_result:
-                hg_result = hg_models.HandgradingResult.objects.validate_and_create(
-                    submission=submission,
-                    group=group, handgrading_rubric=self.rubric)
-                data = hg_result.group.to_dict()
-                data['handgrading_result'] = {
-                    'total_points': hg_result.total_points,
-                    'total_points_possible': hg_result.total_points_possible,
-                    'finished_grading': hg_result.finished_grading
-                }
-            else:
-                data = group.to_dict()
-                data['handgrading_result'] = None
-
-            data['member_names'].sort()
-            data['has_handgradeable_submission'] =\
-                config.submission_status is ag_models.Submission.GradingStatus.finished_grading
-            return data
-
         expected_data = [
-            gen_exp_data(
-                group, config) for group, config in zip(
-                groups, submission_configs)]
+            config.generate_expected_data(group, self.rubric)
+            for group, config in zip(groups, group_handgrading_data_configs)]
         expected_data.sort(key=lambda group: group['member_names'][0])
 
         self.client.force_authenticate(user)

--- a/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
+++ b/autograder/handgrading/tests/test_views/test_handgrading_result_views.py
@@ -618,8 +618,8 @@ class DeleteHandgradingResultTestCase(_SetUp):
 
 @dataclass
 class _GroupHGDataConfig:
-    submission_status: ag_models.Submission.GradingStatus =\
-        ag_models.Submission.GradingStatus.finished_grading
+    submission_status: ag_models.Submission.GradingStatus = (
+        ag_models.Submission.GradingStatus.finished_grading)
     has_handgrading_result: bool = True
 
     def __post_init__(self):
@@ -644,61 +644,46 @@ class _GroupHGDataConfig:
             return None
         return obj_build.make_submission(group=group, status=self.submission_status)
 
-    @staticmethod
-    def format_group_data(group, handgrading_result: dict | None,
-                          has_handgradeable_submission: bool) -> dict:
-        """Format the group data for comparison with the response data."""
-        data = group.to_dict()
-        data['handgrading_result'] = handgrading_result
-        data['member_names'].sort()
-        data['has_handgradeable_submission'] = has_handgradeable_submission
-        return data
-
     def generate_expected_data(self, group: ag_models.Group,
                                rubric: hg_models.HandgradingRubric) -> dict:
         """Generate the expected data base on submission status and handgrading result status."""
         submission = self.create_submission(group)
-        match self.has_handgrading_result, self.submission_status:
+        data = group.to_dict()
+        match self:
             # A finished_grading submission with a handgrading result
-            case True, _:
-                return self.generate_expected_data_with_handgrading_result(
-                    group, submission, rubric)
+            case _GroupHGDataConfig(has_handgrading_result=True,
+                                    submission_status=ag_models.Submission.
+                                    GradingStatus.finished_grading):
+                hg_result = hg_models.HandgradingResult.objects.validate_and_create(
+                    submission=submission,
+                    group=group,
+                    handgrading_rubric=rubric
+                )
+                handgrading_data = {
+                    'total_points': hg_result.total_points,
+                    'total_points_possible': hg_result.total_points_possible,
+                    'finished_grading': hg_result.finished_grading
+                }
+                data['handgrading_result'] = handgrading_data
+                data['has_handgradeable_submission'] = True
+
             # A finished_grading submission without a handgrading result
             # (has_handgradeable_submission would still be true in this case)
-            case False, ag_models.Submission.GradingStatus.finished_grading:
-                return self.format_group_data(group,
-                                              handgrading_result=None,
-                                              has_handgradeable_submission=True)
+            case _GroupHGDataConfig(has_handgrading_result=False,
+                                    submission_status=ag_models.Submission.
+                                    GradingStatus.finished_grading):
+                data['handgrading_result'] = None
+                data['has_handgradeable_submission'] = True
+
             # A submission with any status other than
             # finished_grading (and consequently no handgrading result either).
             # has_handgradeable_submission would be false in this case.
-            case _:
-                return self.format_group_data(group,
-                                              handgrading_result=None,
-                                              has_handgradeable_submission=False)
+            case _GroupHGDataConfig(has_handgrading_result=False):
+                data['handgrading_result'] = None
+                data['has_handgradeable_submission'] = False
 
-    def generate_expected_data_with_handgrading_result(
-            self, group: ag_models.Group, submission: ag_models.Submission,
-            rubric: hg_models.HandgradingRubric) -> dict:
-        """Generate the expected data for a group with a handgrading result."""
-        hg_result = hg_models.HandgradingResult.objects.validate_and_create(
-            submission=submission,
-            group=group,
-            handgrading_rubric=rubric
-        )
-        handgrading_data = {
-            'total_points': hg_result.total_points,
-            'total_points_possible': hg_result.total_points_possible,
-            'finished_grading': hg_result.finished_grading
-        }
-        match self.submission_status:
-            # Is handgradable when the submission has a finished grading status
-            case ag_models.Submission.GradingStatus.finished_grading:
-                return self.format_group_data(
-                    group, handgrading_data, has_handgradeable_submission=True)
-            case _:
-                return self.format_group_data(
-                    group, handgrading_data, has_handgradeable_submission=False)
+        data['member_names'].sort()
+        return data
 
 
 class ListHandgradingResultsViewTestCase(UnitTestBase):

--- a/autograder/handgrading/views/handgrading_result_views.py
+++ b/autograder/handgrading/views/handgrading_result_views.py
@@ -333,7 +333,7 @@ class ListHandgradingResultsView(AGModelAPIView):
                                             },
                                         }
                                     },
-                                    'has_autograded_submissions': {
+                                    'has_handgradeable_submission': {
                                         'description': (
                                             'When this value is false, indicates that '
                                             'this group does not have any submissions whose '
@@ -405,7 +405,7 @@ class ListHandgradingResultsView(AGModelAPIView):
                 for submission in group.submissions.all()
             )
 
-            data['has_autograded_submissions'] = finished_grading_results_exist
+            data['has_handgradeable_submission'] = finished_grading_results_exist
 
             results.append(data)
 

--- a/autograder/handgrading/views/handgrading_result_views.py
+++ b/autograder/handgrading/views/handgrading_result_views.py
@@ -18,7 +18,6 @@ import autograder.handgrading.models as hg_models
 import autograder.rest_api.permissions as ag_permissions
 from autograder import utils
 from autograder.core.models.get_ultimate_submissions import get_ultimate_submission
-from autograder.core.models.submission import Submission
 from autograder.rest_api.schema import (
     AGPatchViewSchemaMixin, AGRetrieveViewSchemaMixin, APITags, CustomViewDict, CustomViewSchema,
     as_content_obj, as_paginated_content_obj, as_schema_ref
@@ -402,7 +401,7 @@ class ListHandgradingResultsView(AGModelAPIView):
                     group.handgrading_result.to_dict(),
                     ['finished_grading', 'total_points', 'total_points_possible'])
             finished_grading_results_exist = any(
-                submission.status == Submission.GradingStatus.finished_grading
+                submission.status == ag_models.Submission.GradingStatus.finished_grading
                 for submission in group.submissions.all()
             )
 

--- a/autograder/handgrading/views/handgrading_result_views.py
+++ b/autograder/handgrading/views/handgrading_result_views.py
@@ -401,8 +401,11 @@ class ListHandgradingResultsView(AGModelAPIView):
                 data['handgrading_result'] = utils.filter_dict(
                     group.handgrading_result.to_dict(),
                     ['finished_grading', 'total_points', 'total_points_possible'])
-            finished_grading_results_exist = group.submissions.filter(
-                status__exact=Submission.GradingStatus.finished_grading).exists()
+            finished_grading_results_exist = any(
+                submission.status == Submission.GradingStatus.finished_grading
+                for submission in group.submissions.all()
+            )
+
             data['has_autograded_submissions'] = finished_grading_results_exist
 
             results.append(data)

--- a/autograder/handgrading/views/handgrading_result_views.py
+++ b/autograder/handgrading/views/handgrading_result_views.py
@@ -332,6 +332,15 @@ class ListHandgradingResultsView(AGModelAPIView):
                                                 'type': 'number', 'format': 'double'
                                             },
                                         }
+                                    },
+                                    'has_autograded_submissions': {
+                                        'description': (
+                                            'When this value is false, indicates that '
+                                            'this group does not have any submissions whose '
+                                            'status is `finished_grading` according '
+                                            'to the autograder test cases.'
+                                        ),
+                                        'type': 'boolean'
                                     }
                                 }
                             }
@@ -391,6 +400,9 @@ class ListHandgradingResultsView(AGModelAPIView):
                 data['handgrading_result'] = utils.filter_dict(
                     group.handgrading_result.to_dict(),
                     ['finished_grading', 'total_points', 'total_points_possible'])
+            finished_grading_results_exist = group.submissions.filter(
+                status__exact=Submission.GradingStatus.finished_grading).exists()
+            data['has_autograded_submissions'] = finished_grading_results_exist
 
             results.append(data)
 

--- a/autograder/handgrading/views/handgrading_result_views.py
+++ b/autograder/handgrading/views/handgrading_result_views.py
@@ -18,6 +18,7 @@ import autograder.handgrading.models as hg_models
 import autograder.rest_api.permissions as ag_permissions
 from autograder import utils
 from autograder.core.models.get_ultimate_submissions import get_ultimate_submission
+from autograder.core.models.submission import Submission
 from autograder.rest_api.schema import (
     AGPatchViewSchemaMixin, AGRetrieveViewSchemaMixin, APITags, CustomViewDict, CustomViewSchema,
     as_content_obj, as_paginated_content_obj, as_schema_ref

--- a/autograder/utils/testing/model_obj_builders.py
+++ b/autograder/utils/testing/model_obj_builders.py
@@ -223,6 +223,14 @@ def make_finished_submission(group: Optional[ag_models.Group] = None,
     return make_submission(status=ag_models.Submission.GradingStatus.finished_grading,
                            group=group,
                            **submission_kwargs)
+    
+
+def make_rejected_submission(group: Optional[ag_models.Group] = None,
+                                **submission_kwargs) -> ag_models.Submission:
+    """Creates a Submission with the status set to rejected."""
+    return make_submission(status=ag_models.Submission.GradingStatus.rejected,
+                                    group=group,
+                                    **submission_kwargs)
 
 
 def make_course(**kwargs) -> ag_models.Course:

--- a/autograder/utils/testing/model_obj_builders.py
+++ b/autograder/utils/testing/model_obj_builders.py
@@ -225,14 +225,6 @@ def make_finished_submission(group: Optional[ag_models.Group] = None,
                            **submission_kwargs)
 
 
-def make_rejected_submission(group: Optional[ag_models.Group] = None,
-                             **submission_kwargs) -> ag_models.Submission:
-    """Creates a Submission with the status set to rejected."""
-    return make_submission(status=ag_models.Submission.GradingStatus.rejected,
-                           group=group,
-                           **submission_kwargs)
-
-
 def make_course(**kwargs) -> ag_models.Course:
     if 'name' not in kwargs:
         kwargs['name'] = 'course{}'.format(get_unique_id())

--- a/autograder/utils/testing/model_obj_builders.py
+++ b/autograder/utils/testing/model_obj_builders.py
@@ -223,14 +223,14 @@ def make_finished_submission(group: Optional[ag_models.Group] = None,
     return make_submission(status=ag_models.Submission.GradingStatus.finished_grading,
                            group=group,
                            **submission_kwargs)
-    
+
 
 def make_rejected_submission(group: Optional[ag_models.Group] = None,
-                                **submission_kwargs) -> ag_models.Submission:
+                             **submission_kwargs) -> ag_models.Submission:
     """Creates a Submission with the status set to rejected."""
     return make_submission(status=ag_models.Submission.GradingStatus.rejected,
-                                    group=group,
-                                    **submission_kwargs)
+                           group=group,
+                           **submission_kwargs)
 
 
 def make_course(**kwargs) -> ag_models.Course:

--- a/schema/schema.yml
+++ b/schema/schema.yml
@@ -1,0 +1,12084 @@
+openapi: 3.0.2
+info:
+  title: Autograder.io API
+  version: 4.5.0
+  description: "\n[View docs with ReDoc](/api/docs/redoc)\n\n[View docs with Swagger](/api/docs)\n\
+    \n### Authenticating\nTo obtain an API token linked to your account, visit\n[https://autograder.io/web/\\\
+    _\\_apitoken\\_\\_](https://autograder.io/web/__apitoken__).\nAfter you've logged\
+    \ in, you will automatically be prompted to download\na text file containing the\
+    \ token. If you are using a custom\ndeployment of autograder.io, replace \"autograder.io\"\
+    \ in the\nURL with the appropriate domain.\n\nWhen sending requests to the API,\
+    \ include the `Authorization`\nheader with value `Token {your token}`, where `{your\
+    \ token}`\nshould be replaced with the token string in the file you downloaded.\n\
+    \nIf your token becomes compromised, you can revoke it\nby sending a DELETE request\
+    \ to the `/api/users/current/revoke_api_token/`\nendpoint (with your token included\
+    \ in the \"Authorization\" header as before).\n            "
+paths:
+  /api/users/current/:
+    get:
+      operationId: getCurrentUser
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: ''
+      tags:
+      - users
+  /api/users/current/can_create_courses/:
+    get:
+      operationId: currentUserCanCreateCourses
+      description: Indicates whether the current user can create empty courses.
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: boolean
+          description: ''
+      tags:
+      - users
+  /api/users/{id}/:
+    get:
+      operationId: getUser
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+          description: ''
+      tags:
+      - users
+  /api/users/{username_or_pk}/late_days/:
+    get:
+      operationId: getUserLateDaysRemaining
+      description: ''
+      parameters:
+      - name: username_or_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: username_or_pk
+        in: path
+        required: true
+        description: The ID or username of the user.
+        schema:
+          oneOf:
+          - type: string
+            format: username
+          - type: integer
+            format: id
+      - name: course_pk
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: id
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - late_days_remaining
+                properties:
+                  late_days_remaining:
+                    type: integer
+          description: ''
+      tags:
+      - courses
+      - users
+    put:
+      operationId: setUserLateDaysRemaining
+      description: ''
+      parameters:
+      - name: username_or_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: username_or_pk
+        in: path
+        required: true
+        description: The ID or username of the user.
+        schema:
+          oneOf:
+          - type: string
+            format: username
+          - type: integer
+            format: id
+      - name: course_pk
+        in: query
+        required: true
+        schema:
+          type: integer
+          format: id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - late_days_remaining
+              properties:
+                late_days_remaining:
+                  type: integer
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - late_days_remaining
+                properties:
+                  late_days_remaining:
+                    type: integer
+          description: ''
+      tags:
+      - courses
+      - users
+  /api/users/{id}/courses_is_admin_for/:
+    get:
+      operationId: coursesIsAdminFor
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - users
+      - courses
+  /api/users/{id}/courses_is_staff_for/:
+    get:
+      operationId: coursesIsStaffFor
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - users
+      - courses
+  /api/users/{id}/courses_is_enrolled_in/:
+    get:
+      operationId: coursesIsEnrolledIn
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - users
+      - courses
+  /api/users/{id}/courses_is_handgrader_for/:
+    get:
+      operationId: coursesIsHandgraderFor
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - users
+      - courses
+  /api/users/{id}/groups_is_member_of/:
+    get:
+      operationId: groupsIsMemberOf
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - users
+      - groups
+  /api/users/{id}/group_invitations_sent/:
+    get:
+      operationId: groupInvitationsSent
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupInvitation'
+          description: ''
+      tags:
+      - users
+      - groups
+  /api/users/{id}/group_invitations_received/:
+    get:
+      operationId: groupInvitationsReceived
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupInvitation'
+          description: ''
+      tags:
+      - users
+      - groups
+  /api/courses/:
+    get:
+      operationId: listCourses
+      description: ''
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - courses
+    post:
+      operationId: createCourse
+      description: ''
+      parameters: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: The name of this course. Must be unique, non-empty
+                    and non-null.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                semester:
+                  description: ''
+                  nullable: true
+                  readOnly: false
+                  enum:
+                  - Fall
+                  - Winter
+                  - Spring
+                  - Summer
+                  type: string
+                year:
+                  description: ''
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                subtitle:
+                  description: An optional descriptive name for the course.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                num_late_days:
+                  description: The number of late days to give to users submitting
+                    to this course's projects.
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                allowed_guest_domain:
+                  description: "When non-empty, indicates that guest users' usernames\n\
+                    \                     must end with this string for them to be\
+                    \ allowed access\n                     to projects that allow\
+                    \ guests.\n                     When empty, indicates that all\
+                    \ guests can access projects\n                     in this course\
+                    \ where guests are allowed access."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+              required:
+              - name
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - courses
+  /api/courses/{id}/:
+    get:
+      operationId: getCourse
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - courses
+    patch:
+      operationId: updateCourse
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: The name of this course. Must be unique, non-empty
+                    and non-null.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                semester:
+                  description: ''
+                  nullable: true
+                  readOnly: false
+                  enum:
+                  - Fall
+                  - Winter
+                  - Spring
+                  - Summer
+                  type: string
+                year:
+                  description: ''
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                subtitle:
+                  description: An optional descriptive name for the course.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                num_late_days:
+                  description: The number of late days to give to users submitting
+                    to this course's projects.
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                allowed_guest_domain:
+                  description: "When non-empty, indicates that guest users' usernames\n\
+                    \                     must end with this string for them to be\
+                    \ allowed access\n                     to projects that allow\
+                    \ guests.\n                     When empty, indicates that all\
+                    \ guests can access projects\n                     in this course\
+                    \ where guests are allowed access."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - courses
+    delete:
+      operationId: pseudoDeleteCourse
+      description: Pseudo-delete this course by clearing its user rosters  and renaming
+        it.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - courses
+  /api/courses/{id}/my_roles/:
+    get:
+      operationId: getUserRoles
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserRoles'
+          description: ''
+      tags:
+      - courses
+      - users
+  /api/course/{name}/{semester}/{year}/:
+    get:
+      operationId: getCourseByFields
+      description: ''
+      parameters:
+      - name: name
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: semester
+        in: path
+        required: true
+        description: ''
+        schema:
+          $ref: '#/components/schemas/Semester'
+      - name: year
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - courses
+  /api/courses/{id}/admins/:
+    get:
+      operationId: listCourseAdmins
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: ''
+      tags:
+      - rosters
+    post:
+      operationId: addCourseAdmins
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - new_admins
+              properties:
+                new_admins:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+                  description: Usernames to be granted admin privileges for the course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+    patch:
+      operationId: removeCourseAdmins
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - remove_admins
+              properties:
+                remove_admins:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/User'
+                  description: Users to revoke admin privileges from for the course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+  /api/courses/{id}/staff/:
+    get:
+      operationId: listCourseStaff
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: ''
+      tags:
+      - rosters
+    post:
+      operationId: addCourseStaff
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - new_staff
+              properties:
+                new_staff:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+                  description: Usernames to be granted staff privileges for the course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+    patch:
+      operationId: removeCourseStaff
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - remove_staff
+              properties:
+                remove_staff:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/User'
+                  description: Users whose staff privileges should be revoked for
+                    the course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+  /api/courses/{id}/students/:
+    get:
+      operationId: listCourseStudents
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: ''
+      tags:
+      - rosters
+    post:
+      operationId: addCourseStudents
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - new_students
+              properties:
+                new_students:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+                  description: Usernames to be granted student privileges for the
+                    course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+    put:
+      operationId: setCourseStudents
+      description: 'Completely REPLACES the student roster with the usernames
+
+        included in the request.'
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - new_students
+              properties:
+                new_students:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+                  description: Usernames to be granted student privileges for the
+                    course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+    patch:
+      operationId: removeCourseStudents
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - remove_students
+              properties:
+                remove_students:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/User'
+                  description: Users whose student privileges should be revoked for
+                    the course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+  /api/courses/{id}/handgraders/:
+    get:
+      operationId: listCourseHandgraders
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
+          description: ''
+      tags:
+      - rosters
+    post:
+      operationId: addCourseHandgraders
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - new_handgraders
+              properties:
+                new_handgraders:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+                  description: Usernames to be granted handgrading privileges for
+                    the course.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+    patch:
+      operationId: removeCourseHandgraders
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - remove_handgraders
+              properties:
+                remove_handgraders:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/User'
+                  description: Users to revoke handgrading privileges from.
+        required: true
+      responses:
+        '204':
+          description: ''
+      tags:
+      - rosters
+  /api/courses/{id}/projects/:
+    get:
+      operationId: listProjects
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Project'
+          description: ''
+      tags:
+      - projects
+    post:
+      operationId: createProject
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this project.\n        \
+                    \    Must be non-empty and non-null.\n            Must be unique\
+                    \ among Projects associated with\n            a given course.\n\
+                    \            This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                course:
+                  description: "The Course this project belongs to.\n            This\
+                    \ field is REQUIRED."
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                visible_to_students:
+                  description: "Whether information about this Project can\n     \
+                    \       be viewed by students."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                closing_time:
+                  description: "The date and time that this project should stop\n\
+                    \            accepting submissions.\n            A value of None\
+                    \ indicates that this project should\n            stay open.\n\
+                    \            In the API, this field is hidden from non-admins."
+                  nullable: true
+                  readOnly: false
+                  type: string
+                  format: date-time
+                soft_closing_time:
+                  description: "The date and time that should be displayed as the\n\
+                    \            due date for this project. Unlike closing_time,\n\
+                    \            soft_closing_time does not affect whether submissions\
+                    \ are\n            actually accepted.\n            If not None\
+                    \ and closing_time is not None, this value must be\n         \
+                    \   less than (before) closing_time."
+                  nullable: true
+                  readOnly: false
+                  type: string
+                  format: date-time
+                disallow_student_submissions:
+                  description: "A hard override that indicates that students should\n\
+                    \            be prevented from submitting even if visible_to_students\
+                    \ is\n            True and it is before closing_time."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                disallow_group_registration:
+                  description: "A hard override that indicates that students should\n\
+                    \            not be able to send, accept, or reject group\n  \
+                    \          invitations."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                guests_can_submit:
+                  description: "By default, only admins, staff, and students\n   \
+                    \         for a given Course can view and submit to its Projects.\n\
+                    \            When True, submissions will be accepted from guests\n\
+                    \            with the following caveats:\n                - Guests\
+                    \ must be given a direct link to the project.\n              \
+                    \  - When group work is allowed, guests can\n                only\
+                    \ be in groups with other guests."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                min_group_size:
+                  description: "The minimum number of students that can work in a\n\
+                    \            group on this project.\n            Must be >= 1.\n\
+                    \            Must be <= max_group_size."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                max_group_size:
+                  description: "The maximum number of students that can work in a\n\
+                    \            group on this project.\n            Must be >= 1.\n\
+                    \            Must be >= min_group_size."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                submission_limit_per_day:
+                  description: "The number of submissions each group is allowed per\n\
+                    \            day before either reducing feedback or preventing\
+                    \ further\n            submissions. A value of None indicates\
+                    \ no limit."
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                allow_submissions_past_limit:
+                  description: "Whether to allow additional submissions after a\n\
+                    \            group has submitted submission_limit_per_day times."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                groups_combine_daily_submissions:
+                  description: "If True, group members can \"pool\" their daily submissions.\n\
+                    \            For example, if submission_limit_per_day is 3,\n\
+                    \            a group with 2 members would get 6 submissions per\
+                    \ day."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                submission_limit_reset_time:
+                  description: "The time that marks the beginning and end of the 24\n\
+                    \            hour period during which submissions should be counted\n\
+                    \            towards the daily limit. Defaults to 00:00:00."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                  format: time
+                submission_limit_reset_timezone:
+                  description: "A string representing the timezone to use when computing\n\
+                    \            how many submissions a group has made in a 24 hour\
+                    \ period."
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - Africa/Abidjan
+                  - Africa/Accra
+                  - Africa/Addis_Ababa
+                  - Africa/Algiers
+                  - Africa/Asmara
+                  - Africa/Asmera
+                  - Africa/Bamako
+                  - Africa/Bangui
+                  - Africa/Banjul
+                  - Africa/Bissau
+                  - Africa/Blantyre
+                  - Africa/Brazzaville
+                  - Africa/Bujumbura
+                  - Africa/Cairo
+                  - Africa/Casablanca
+                  - Africa/Ceuta
+                  - Africa/Conakry
+                  - Africa/Dakar
+                  - Africa/Dar_es_Salaam
+                  - Africa/Djibouti
+                  - Africa/Douala
+                  - Africa/El_Aaiun
+                  - Africa/Freetown
+                  - Africa/Gaborone
+                  - Africa/Harare
+                  - Africa/Johannesburg
+                  - Africa/Juba
+                  - Africa/Kampala
+                  - Africa/Khartoum
+                  - Africa/Kigali
+                  - Africa/Kinshasa
+                  - Africa/Lagos
+                  - Africa/Libreville
+                  - Africa/Lome
+                  - Africa/Luanda
+                  - Africa/Lubumbashi
+                  - Africa/Lusaka
+                  - Africa/Malabo
+                  - Africa/Maputo
+                  - Africa/Maseru
+                  - Africa/Mbabane
+                  - Africa/Mogadishu
+                  - Africa/Monrovia
+                  - Africa/Nairobi
+                  - Africa/Ndjamena
+                  - Africa/Niamey
+                  - Africa/Nouakchott
+                  - Africa/Ouagadougou
+                  - Africa/Porto-Novo
+                  - Africa/Sao_Tome
+                  - Africa/Timbuktu
+                  - Africa/Tripoli
+                  - Africa/Tunis
+                  - Africa/Windhoek
+                  - America/Adak
+                  - America/Anchorage
+                  - America/Anguilla
+                  - America/Antigua
+                  - America/Araguaina
+                  - America/Argentina/Buenos_Aires
+                  - America/Argentina/Catamarca
+                  - America/Argentina/ComodRivadavia
+                  - America/Argentina/Cordoba
+                  - America/Argentina/Jujuy
+                  - America/Argentina/La_Rioja
+                  - America/Argentina/Mendoza
+                  - America/Argentina/Rio_Gallegos
+                  - America/Argentina/Salta
+                  - America/Argentina/San_Juan
+                  - America/Argentina/San_Luis
+                  - America/Argentina/Tucuman
+                  - America/Argentina/Ushuaia
+                  - America/Aruba
+                  - America/Asuncion
+                  - America/Atikokan
+                  - America/Atka
+                  - America/Bahia
+                  - America/Bahia_Banderas
+                  - America/Barbados
+                  - America/Belem
+                  - America/Belize
+                  - America/Blanc-Sablon
+                  - America/Boa_Vista
+                  - America/Bogota
+                  - America/Boise
+                  - America/Buenos_Aires
+                  - America/Cambridge_Bay
+                  - America/Campo_Grande
+                  - America/Cancun
+                  - America/Caracas
+                  - America/Catamarca
+                  - America/Cayenne
+                  - America/Cayman
+                  - America/Chicago
+                  - America/Chihuahua
+                  - America/Ciudad_Juarez
+                  - America/Coral_Harbour
+                  - America/Cordoba
+                  - America/Costa_Rica
+                  - America/Creston
+                  - America/Cuiaba
+                  - America/Curacao
+                  - America/Danmarkshavn
+                  - America/Dawson
+                  - America/Dawson_Creek
+                  - America/Denver
+                  - America/Detroit
+                  - America/Dominica
+                  - America/Edmonton
+                  - America/Eirunepe
+                  - America/El_Salvador
+                  - America/Ensenada
+                  - America/Fort_Nelson
+                  - America/Fort_Wayne
+                  - America/Fortaleza
+                  - America/Glace_Bay
+                  - America/Godthab
+                  - America/Goose_Bay
+                  - America/Grand_Turk
+                  - America/Grenada
+                  - America/Guadeloupe
+                  - America/Guatemala
+                  - America/Guayaquil
+                  - America/Guyana
+                  - America/Halifax
+                  - America/Havana
+                  - America/Hermosillo
+                  - America/Indiana/Indianapolis
+                  - America/Indiana/Knox
+                  - America/Indiana/Marengo
+                  - America/Indiana/Petersburg
+                  - America/Indiana/Tell_City
+                  - America/Indiana/Vevay
+                  - America/Indiana/Vincennes
+                  - America/Indiana/Winamac
+                  - America/Indianapolis
+                  - America/Inuvik
+                  - America/Iqaluit
+                  - America/Jamaica
+                  - America/Jujuy
+                  - America/Juneau
+                  - America/Kentucky/Louisville
+                  - America/Kentucky/Monticello
+                  - America/Knox_IN
+                  - America/Kralendijk
+                  - America/La_Paz
+                  - America/Lima
+                  - America/Los_Angeles
+                  - America/Louisville
+                  - America/Lower_Princes
+                  - America/Maceio
+                  - America/Managua
+                  - America/Manaus
+                  - America/Marigot
+                  - America/Martinique
+                  - America/Matamoros
+                  - America/Mazatlan
+                  - America/Mendoza
+                  - America/Menominee
+                  - America/Merida
+                  - America/Metlakatla
+                  - America/Mexico_City
+                  - America/Miquelon
+                  - America/Moncton
+                  - America/Monterrey
+                  - America/Montevideo
+                  - America/Montreal
+                  - America/Montserrat
+                  - America/Nassau
+                  - America/New_York
+                  - America/Nipigon
+                  - America/Nome
+                  - America/Noronha
+                  - America/North_Dakota/Beulah
+                  - America/North_Dakota/Center
+                  - America/North_Dakota/New_Salem
+                  - America/Nuuk
+                  - America/Ojinaga
+                  - America/Panama
+                  - America/Pangnirtung
+                  - America/Paramaribo
+                  - America/Phoenix
+                  - America/Port-au-Prince
+                  - America/Port_of_Spain
+                  - America/Porto_Acre
+                  - America/Porto_Velho
+                  - America/Puerto_Rico
+                  - America/Punta_Arenas
+                  - America/Rainy_River
+                  - America/Rankin_Inlet
+                  - America/Recife
+                  - America/Regina
+                  - America/Resolute
+                  - America/Rio_Branco
+                  - America/Rosario
+                  - America/Santa_Isabel
+                  - America/Santarem
+                  - America/Santiago
+                  - America/Santo_Domingo
+                  - America/Sao_Paulo
+                  - America/Scoresbysund
+                  - America/Shiprock
+                  - America/Sitka
+                  - America/St_Barthelemy
+                  - America/St_Johns
+                  - America/St_Kitts
+                  - America/St_Lucia
+                  - America/St_Thomas
+                  - America/St_Vincent
+                  - America/Swift_Current
+                  - America/Tegucigalpa
+                  - America/Thule
+                  - America/Thunder_Bay
+                  - America/Tijuana
+                  - America/Toronto
+                  - America/Tortola
+                  - America/Vancouver
+                  - America/Virgin
+                  - America/Whitehorse
+                  - America/Winnipeg
+                  - America/Yakutat
+                  - America/Yellowknife
+                  - Antarctica/Casey
+                  - Antarctica/Davis
+                  - Antarctica/DumontDUrville
+                  - Antarctica/Macquarie
+                  - Antarctica/Mawson
+                  - Antarctica/McMurdo
+                  - Antarctica/Palmer
+                  - Antarctica/Rothera
+                  - Antarctica/South_Pole
+                  - Antarctica/Syowa
+                  - Antarctica/Troll
+                  - Antarctica/Vostok
+                  - Arctic/Longyearbyen
+                  - Asia/Aden
+                  - Asia/Almaty
+                  - Asia/Amman
+                  - Asia/Anadyr
+                  - Asia/Aqtau
+                  - Asia/Aqtobe
+                  - Asia/Ashgabat
+                  - Asia/Ashkhabad
+                  - Asia/Atyrau
+                  - Asia/Baghdad
+                  - Asia/Bahrain
+                  - Asia/Baku
+                  - Asia/Bangkok
+                  - Asia/Barnaul
+                  - Asia/Beirut
+                  - Asia/Bishkek
+                  - Asia/Brunei
+                  - Asia/Calcutta
+                  - Asia/Chita
+                  - Asia/Choibalsan
+                  - Asia/Chongqing
+                  - Asia/Chungking
+                  - Asia/Colombo
+                  - Asia/Dacca
+                  - Asia/Damascus
+                  - Asia/Dhaka
+                  - Asia/Dili
+                  - Asia/Dubai
+                  - Asia/Dushanbe
+                  - Asia/Famagusta
+                  - Asia/Gaza
+                  - Asia/Harbin
+                  - Asia/Hebron
+                  - Asia/Ho_Chi_Minh
+                  - Asia/Hong_Kong
+                  - Asia/Hovd
+                  - Asia/Irkutsk
+                  - Asia/Istanbul
+                  - Asia/Jakarta
+                  - Asia/Jayapura
+                  - Asia/Jerusalem
+                  - Asia/Kabul
+                  - Asia/Kamchatka
+                  - Asia/Karachi
+                  - Asia/Kashgar
+                  - Asia/Kathmandu
+                  - Asia/Katmandu
+                  - Asia/Khandyga
+                  - Asia/Kolkata
+                  - Asia/Krasnoyarsk
+                  - Asia/Kuala_Lumpur
+                  - Asia/Kuching
+                  - Asia/Kuwait
+                  - Asia/Macao
+                  - Asia/Macau
+                  - Asia/Magadan
+                  - Asia/Makassar
+                  - Asia/Manila
+                  - Asia/Muscat
+                  - Asia/Nicosia
+                  - Asia/Novokuznetsk
+                  - Asia/Novosibirsk
+                  - Asia/Omsk
+                  - Asia/Oral
+                  - Asia/Phnom_Penh
+                  - Asia/Pontianak
+                  - Asia/Pyongyang
+                  - Asia/Qatar
+                  - Asia/Qostanay
+                  - Asia/Qyzylorda
+                  - Asia/Rangoon
+                  - Asia/Riyadh
+                  - Asia/Saigon
+                  - Asia/Sakhalin
+                  - Asia/Samarkand
+                  - Asia/Seoul
+                  - Asia/Shanghai
+                  - Asia/Singapore
+                  - Asia/Srednekolymsk
+                  - Asia/Taipei
+                  - Asia/Tashkent
+                  - Asia/Tbilisi
+                  - Asia/Tehran
+                  - Asia/Tel_Aviv
+                  - Asia/Thimbu
+                  - Asia/Thimphu
+                  - Asia/Tokyo
+                  - Asia/Tomsk
+                  - Asia/Ujung_Pandang
+                  - Asia/Ulaanbaatar
+                  - Asia/Ulan_Bator
+                  - Asia/Urumqi
+                  - Asia/Ust-Nera
+                  - Asia/Vientiane
+                  - Asia/Vladivostok
+                  - Asia/Yakutsk
+                  - Asia/Yangon
+                  - Asia/Yekaterinburg
+                  - Asia/Yerevan
+                  - Atlantic/Azores
+                  - Atlantic/Bermuda
+                  - Atlantic/Canary
+                  - Atlantic/Cape_Verde
+                  - Atlantic/Faeroe
+                  - Atlantic/Faroe
+                  - Atlantic/Jan_Mayen
+                  - Atlantic/Madeira
+                  - Atlantic/Reykjavik
+                  - Atlantic/South_Georgia
+                  - Atlantic/St_Helena
+                  - Atlantic/Stanley
+                  - Australia/ACT
+                  - Australia/Adelaide
+                  - Australia/Brisbane
+                  - Australia/Broken_Hill
+                  - Australia/Canberra
+                  - Australia/Currie
+                  - Australia/Darwin
+                  - Australia/Eucla
+                  - Australia/Hobart
+                  - Australia/LHI
+                  - Australia/Lindeman
+                  - Australia/Lord_Howe
+                  - Australia/Melbourne
+                  - Australia/NSW
+                  - Australia/North
+                  - Australia/Perth
+                  - Australia/Queensland
+                  - Australia/South
+                  - Australia/Sydney
+                  - Australia/Tasmania
+                  - Australia/Victoria
+                  - Australia/West
+                  - Australia/Yancowinna
+                  - Brazil/Acre
+                  - Brazil/DeNoronha
+                  - Brazil/East
+                  - Brazil/West
+                  - CET
+                  - CST6CDT
+                  - Canada/Atlantic
+                  - Canada/Central
+                  - Canada/Eastern
+                  - Canada/Mountain
+                  - Canada/Newfoundland
+                  - Canada/Pacific
+                  - Canada/Saskatchewan
+                  - Canada/Yukon
+                  - Chile/Continental
+                  - Chile/EasterIsland
+                  - Cuba
+                  - EET
+                  - EST
+                  - EST5EDT
+                  - Egypt
+                  - Eire
+                  - Etc/GMT
+                  - Etc/GMT+0
+                  - Etc/GMT+1
+                  - Etc/GMT+10
+                  - Etc/GMT+11
+                  - Etc/GMT+12
+                  - Etc/GMT+2
+                  - Etc/GMT+3
+                  - Etc/GMT+4
+                  - Etc/GMT+5
+                  - Etc/GMT+6
+                  - Etc/GMT+7
+                  - Etc/GMT+8
+                  - Etc/GMT+9
+                  - Etc/GMT-0
+                  - Etc/GMT-1
+                  - Etc/GMT-10
+                  - Etc/GMT-11
+                  - Etc/GMT-12
+                  - Etc/GMT-13
+                  - Etc/GMT-14
+                  - Etc/GMT-2
+                  - Etc/GMT-3
+                  - Etc/GMT-4
+                  - Etc/GMT-5
+                  - Etc/GMT-6
+                  - Etc/GMT-7
+                  - Etc/GMT-8
+                  - Etc/GMT-9
+                  - Etc/GMT0
+                  - Etc/Greenwich
+                  - Etc/UCT
+                  - Etc/UTC
+                  - Etc/Universal
+                  - Etc/Zulu
+                  - Europe/Amsterdam
+                  - Europe/Andorra
+                  - Europe/Astrakhan
+                  - Europe/Athens
+                  - Europe/Belfast
+                  - Europe/Belgrade
+                  - Europe/Berlin
+                  - Europe/Bratislava
+                  - Europe/Brussels
+                  - Europe/Bucharest
+                  - Europe/Budapest
+                  - Europe/Busingen
+                  - Europe/Chisinau
+                  - Europe/Copenhagen
+                  - Europe/Dublin
+                  - Europe/Gibraltar
+                  - Europe/Guernsey
+                  - Europe/Helsinki
+                  - Europe/Isle_of_Man
+                  - Europe/Istanbul
+                  - Europe/Jersey
+                  - Europe/Kaliningrad
+                  - Europe/Kiev
+                  - Europe/Kirov
+                  - Europe/Kyiv
+                  - Europe/Lisbon
+                  - Europe/Ljubljana
+                  - Europe/London
+                  - Europe/Luxembourg
+                  - Europe/Madrid
+                  - Europe/Malta
+                  - Europe/Mariehamn
+                  - Europe/Minsk
+                  - Europe/Monaco
+                  - Europe/Moscow
+                  - Europe/Nicosia
+                  - Europe/Oslo
+                  - Europe/Paris
+                  - Europe/Podgorica
+                  - Europe/Prague
+                  - Europe/Riga
+                  - Europe/Rome
+                  - Europe/Samara
+                  - Europe/San_Marino
+                  - Europe/Sarajevo
+                  - Europe/Saratov
+                  - Europe/Simferopol
+                  - Europe/Skopje
+                  - Europe/Sofia
+                  - Europe/Stockholm
+                  - Europe/Tallinn
+                  - Europe/Tirane
+                  - Europe/Tiraspol
+                  - Europe/Ulyanovsk
+                  - Europe/Uzhgorod
+                  - Europe/Vaduz
+                  - Europe/Vatican
+                  - Europe/Vienna
+                  - Europe/Vilnius
+                  - Europe/Volgograd
+                  - Europe/Warsaw
+                  - Europe/Zagreb
+                  - Europe/Zaporozhye
+                  - Europe/Zurich
+                  - Factory
+                  - GB
+                  - GB-Eire
+                  - GMT
+                  - GMT+0
+                  - GMT-0
+                  - GMT0
+                  - Greenwich
+                  - HST
+                  - Hongkong
+                  - Iceland
+                  - Indian/Antananarivo
+                  - Indian/Chagos
+                  - Indian/Christmas
+                  - Indian/Cocos
+                  - Indian/Comoro
+                  - Indian/Kerguelen
+                  - Indian/Mahe
+                  - Indian/Maldives
+                  - Indian/Mauritius
+                  - Indian/Mayotte
+                  - Indian/Reunion
+                  - Iran
+                  - Israel
+                  - Jamaica
+                  - Japan
+                  - Kwajalein
+                  - Libya
+                  - MET
+                  - MST
+                  - MST7MDT
+                  - Mexico/BajaNorte
+                  - Mexico/BajaSur
+                  - Mexico/General
+                  - NZ
+                  - NZ-CHAT
+                  - Navajo
+                  - PRC
+                  - PST8PDT
+                  - Pacific/Apia
+                  - Pacific/Auckland
+                  - Pacific/Bougainville
+                  - Pacific/Chatham
+                  - Pacific/Chuuk
+                  - Pacific/Easter
+                  - Pacific/Efate
+                  - Pacific/Enderbury
+                  - Pacific/Fakaofo
+                  - Pacific/Fiji
+                  - Pacific/Funafuti
+                  - Pacific/Galapagos
+                  - Pacific/Gambier
+                  - Pacific/Guadalcanal
+                  - Pacific/Guam
+                  - Pacific/Honolulu
+                  - Pacific/Johnston
+                  - Pacific/Kanton
+                  - Pacific/Kiritimati
+                  - Pacific/Kosrae
+                  - Pacific/Kwajalein
+                  - Pacific/Majuro
+                  - Pacific/Marquesas
+                  - Pacific/Midway
+                  - Pacific/Nauru
+                  - Pacific/Niue
+                  - Pacific/Norfolk
+                  - Pacific/Noumea
+                  - Pacific/Pago_Pago
+                  - Pacific/Palau
+                  - Pacific/Pitcairn
+                  - Pacific/Pohnpei
+                  - Pacific/Ponape
+                  - Pacific/Port_Moresby
+                  - Pacific/Rarotonga
+                  - Pacific/Saipan
+                  - Pacific/Samoa
+                  - Pacific/Tahiti
+                  - Pacific/Tarawa
+                  - Pacific/Tongatapu
+                  - Pacific/Truk
+                  - Pacific/Wake
+                  - Pacific/Wallis
+                  - Pacific/Yap
+                  - Poland
+                  - Portugal
+                  - ROC
+                  - ROK
+                  - Singapore
+                  - Turkey
+                  - UCT
+                  - US/Alaska
+                  - US/Aleutian
+                  - US/Arizona
+                  - US/Central
+                  - US/East-Indiana
+                  - US/Eastern
+                  - US/Hawaii
+                  - US/Indiana-Starke
+                  - US/Michigan
+                  - US/Mountain
+                  - US/Pacific
+                  - US/Samoa
+                  - UTC
+                  - Universal
+                  - W-SU
+                  - WET
+                  - Zulu
+                  - localtime
+                  type: string
+                num_bonus_submissions:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                total_submission_limit:
+                  description: "The maximum number of times a Group can submit to\n\
+                    \            this Project EVER."
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                allow_late_days:
+                  description: "Whether to allow the use of late days for submitting\n\
+                    \            past the deadline."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ultimate_submission_policy:
+                  description: "The \"ultimate\" submission for a group is the one\n\
+                    \            that will be used for final grading. This field specifies\n\
+                    \            how the ultimate submission should be determined."
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - most_recent
+                  - best_basic_score
+                  - best
+                  type: string
+                hide_ultimate_submission_fdbk:
+                  description: "A hard override that indicates that ultimate\n   \
+                    \         submission feedback should not be shown, even if the\n\
+                    \            appropriate criteria are met."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                instructor_files:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InstructorFile'
+                expected_student_files:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ExpectedStudentFile'
+                has_handgrading_rubric:
+                  description: Whether this project has a handgrading rubric.
+                  readOnly: true
+                  type: boolean
+                send_email_on_submission_received:
+                  description: "If True, users will receive a confirmation email\n\
+                    \            every time a submission of theirs is recorded in\
+                    \ the\n            database."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                send_email_on_non_deferred_tests_finished:
+                  description: "If True, users will receive a confirmation email\n\
+                    \            once all non-deferred test cases for their submission\
+                    \ are\n            finished grading."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                use_honor_pledge:
+                  description: "If True, then the frontend website should require\n\
+                    \            students to acknowledge an honor pledge. The text\
+                    \ of the\n            honor pledge is stored in honor_pledge_text."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                honor_pledge_text:
+                  description: The text of the honor pledge to display.
+                  nullable: false
+                  readOnly: false
+                  type: string
+              required:
+              - name
+              - course
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+      tags:
+      - projects
+  /api/projects/{id}/:
+    get:
+      operationId: getProject
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+      tags:
+      - projects
+    patch:
+      operationId: updateProject
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this project.\n        \
+                    \    Must be non-empty and non-null.\n            Must be unique\
+                    \ among Projects associated with\n            a given course.\n\
+                    \            This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                course:
+                  description: "The Course this project belongs to.\n            This\
+                    \ field is REQUIRED."
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                visible_to_students:
+                  description: "Whether information about this Project can\n     \
+                    \       be viewed by students."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                closing_time:
+                  description: "The date and time that this project should stop\n\
+                    \            accepting submissions.\n            A value of None\
+                    \ indicates that this project should\n            stay open.\n\
+                    \            In the API, this field is hidden from non-admins."
+                  nullable: true
+                  readOnly: false
+                  type: string
+                  format: date-time
+                soft_closing_time:
+                  description: "The date and time that should be displayed as the\n\
+                    \            due date for this project. Unlike closing_time,\n\
+                    \            soft_closing_time does not affect whether submissions\
+                    \ are\n            actually accepted.\n            If not None\
+                    \ and closing_time is not None, this value must be\n         \
+                    \   less than (before) closing_time."
+                  nullable: true
+                  readOnly: false
+                  type: string
+                  format: date-time
+                disallow_student_submissions:
+                  description: "A hard override that indicates that students should\n\
+                    \            be prevented from submitting even if visible_to_students\
+                    \ is\n            True and it is before closing_time."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                disallow_group_registration:
+                  description: "A hard override that indicates that students should\n\
+                    \            not be able to send, accept, or reject group\n  \
+                    \          invitations."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                guests_can_submit:
+                  description: "By default, only admins, staff, and students\n   \
+                    \         for a given Course can view and submit to its Projects.\n\
+                    \            When True, submissions will be accepted from guests\n\
+                    \            with the following caveats:\n                - Guests\
+                    \ must be given a direct link to the project.\n              \
+                    \  - When group work is allowed, guests can\n                only\
+                    \ be in groups with other guests."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                min_group_size:
+                  description: "The minimum number of students that can work in a\n\
+                    \            group on this project.\n            Must be >= 1.\n\
+                    \            Must be <= max_group_size."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                max_group_size:
+                  description: "The maximum number of students that can work in a\n\
+                    \            group on this project.\n            Must be >= 1.\n\
+                    \            Must be >= min_group_size."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                submission_limit_per_day:
+                  description: "The number of submissions each group is allowed per\n\
+                    \            day before either reducing feedback or preventing\
+                    \ further\n            submissions. A value of None indicates\
+                    \ no limit."
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                allow_submissions_past_limit:
+                  description: "Whether to allow additional submissions after a\n\
+                    \            group has submitted submission_limit_per_day times."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                groups_combine_daily_submissions:
+                  description: "If True, group members can \"pool\" their daily submissions.\n\
+                    \            For example, if submission_limit_per_day is 3,\n\
+                    \            a group with 2 members would get 6 submissions per\
+                    \ day."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                submission_limit_reset_time:
+                  description: "The time that marks the beginning and end of the 24\n\
+                    \            hour period during which submissions should be counted\n\
+                    \            towards the daily limit. Defaults to 00:00:00."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                  format: time
+                submission_limit_reset_timezone:
+                  description: "A string representing the timezone to use when computing\n\
+                    \            how many submissions a group has made in a 24 hour\
+                    \ period."
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - Africa/Abidjan
+                  - Africa/Accra
+                  - Africa/Addis_Ababa
+                  - Africa/Algiers
+                  - Africa/Asmara
+                  - Africa/Asmera
+                  - Africa/Bamako
+                  - Africa/Bangui
+                  - Africa/Banjul
+                  - Africa/Bissau
+                  - Africa/Blantyre
+                  - Africa/Brazzaville
+                  - Africa/Bujumbura
+                  - Africa/Cairo
+                  - Africa/Casablanca
+                  - Africa/Ceuta
+                  - Africa/Conakry
+                  - Africa/Dakar
+                  - Africa/Dar_es_Salaam
+                  - Africa/Djibouti
+                  - Africa/Douala
+                  - Africa/El_Aaiun
+                  - Africa/Freetown
+                  - Africa/Gaborone
+                  - Africa/Harare
+                  - Africa/Johannesburg
+                  - Africa/Juba
+                  - Africa/Kampala
+                  - Africa/Khartoum
+                  - Africa/Kigali
+                  - Africa/Kinshasa
+                  - Africa/Lagos
+                  - Africa/Libreville
+                  - Africa/Lome
+                  - Africa/Luanda
+                  - Africa/Lubumbashi
+                  - Africa/Lusaka
+                  - Africa/Malabo
+                  - Africa/Maputo
+                  - Africa/Maseru
+                  - Africa/Mbabane
+                  - Africa/Mogadishu
+                  - Africa/Monrovia
+                  - Africa/Nairobi
+                  - Africa/Ndjamena
+                  - Africa/Niamey
+                  - Africa/Nouakchott
+                  - Africa/Ouagadougou
+                  - Africa/Porto-Novo
+                  - Africa/Sao_Tome
+                  - Africa/Timbuktu
+                  - Africa/Tripoli
+                  - Africa/Tunis
+                  - Africa/Windhoek
+                  - America/Adak
+                  - America/Anchorage
+                  - America/Anguilla
+                  - America/Antigua
+                  - America/Araguaina
+                  - America/Argentina/Buenos_Aires
+                  - America/Argentina/Catamarca
+                  - America/Argentina/ComodRivadavia
+                  - America/Argentina/Cordoba
+                  - America/Argentina/Jujuy
+                  - America/Argentina/La_Rioja
+                  - America/Argentina/Mendoza
+                  - America/Argentina/Rio_Gallegos
+                  - America/Argentina/Salta
+                  - America/Argentina/San_Juan
+                  - America/Argentina/San_Luis
+                  - America/Argentina/Tucuman
+                  - America/Argentina/Ushuaia
+                  - America/Aruba
+                  - America/Asuncion
+                  - America/Atikokan
+                  - America/Atka
+                  - America/Bahia
+                  - America/Bahia_Banderas
+                  - America/Barbados
+                  - America/Belem
+                  - America/Belize
+                  - America/Blanc-Sablon
+                  - America/Boa_Vista
+                  - America/Bogota
+                  - America/Boise
+                  - America/Buenos_Aires
+                  - America/Cambridge_Bay
+                  - America/Campo_Grande
+                  - America/Cancun
+                  - America/Caracas
+                  - America/Catamarca
+                  - America/Cayenne
+                  - America/Cayman
+                  - America/Chicago
+                  - America/Chihuahua
+                  - America/Ciudad_Juarez
+                  - America/Coral_Harbour
+                  - America/Cordoba
+                  - America/Costa_Rica
+                  - America/Creston
+                  - America/Cuiaba
+                  - America/Curacao
+                  - America/Danmarkshavn
+                  - America/Dawson
+                  - America/Dawson_Creek
+                  - America/Denver
+                  - America/Detroit
+                  - America/Dominica
+                  - America/Edmonton
+                  - America/Eirunepe
+                  - America/El_Salvador
+                  - America/Ensenada
+                  - America/Fort_Nelson
+                  - America/Fort_Wayne
+                  - America/Fortaleza
+                  - America/Glace_Bay
+                  - America/Godthab
+                  - America/Goose_Bay
+                  - America/Grand_Turk
+                  - America/Grenada
+                  - America/Guadeloupe
+                  - America/Guatemala
+                  - America/Guayaquil
+                  - America/Guyana
+                  - America/Halifax
+                  - America/Havana
+                  - America/Hermosillo
+                  - America/Indiana/Indianapolis
+                  - America/Indiana/Knox
+                  - America/Indiana/Marengo
+                  - America/Indiana/Petersburg
+                  - America/Indiana/Tell_City
+                  - America/Indiana/Vevay
+                  - America/Indiana/Vincennes
+                  - America/Indiana/Winamac
+                  - America/Indianapolis
+                  - America/Inuvik
+                  - America/Iqaluit
+                  - America/Jamaica
+                  - America/Jujuy
+                  - America/Juneau
+                  - America/Kentucky/Louisville
+                  - America/Kentucky/Monticello
+                  - America/Knox_IN
+                  - America/Kralendijk
+                  - America/La_Paz
+                  - America/Lima
+                  - America/Los_Angeles
+                  - America/Louisville
+                  - America/Lower_Princes
+                  - America/Maceio
+                  - America/Managua
+                  - America/Manaus
+                  - America/Marigot
+                  - America/Martinique
+                  - America/Matamoros
+                  - America/Mazatlan
+                  - America/Mendoza
+                  - America/Menominee
+                  - America/Merida
+                  - America/Metlakatla
+                  - America/Mexico_City
+                  - America/Miquelon
+                  - America/Moncton
+                  - America/Monterrey
+                  - America/Montevideo
+                  - America/Montreal
+                  - America/Montserrat
+                  - America/Nassau
+                  - America/New_York
+                  - America/Nipigon
+                  - America/Nome
+                  - America/Noronha
+                  - America/North_Dakota/Beulah
+                  - America/North_Dakota/Center
+                  - America/North_Dakota/New_Salem
+                  - America/Nuuk
+                  - America/Ojinaga
+                  - America/Panama
+                  - America/Pangnirtung
+                  - America/Paramaribo
+                  - America/Phoenix
+                  - America/Port-au-Prince
+                  - America/Port_of_Spain
+                  - America/Porto_Acre
+                  - America/Porto_Velho
+                  - America/Puerto_Rico
+                  - America/Punta_Arenas
+                  - America/Rainy_River
+                  - America/Rankin_Inlet
+                  - America/Recife
+                  - America/Regina
+                  - America/Resolute
+                  - America/Rio_Branco
+                  - America/Rosario
+                  - America/Santa_Isabel
+                  - America/Santarem
+                  - America/Santiago
+                  - America/Santo_Domingo
+                  - America/Sao_Paulo
+                  - America/Scoresbysund
+                  - America/Shiprock
+                  - America/Sitka
+                  - America/St_Barthelemy
+                  - America/St_Johns
+                  - America/St_Kitts
+                  - America/St_Lucia
+                  - America/St_Thomas
+                  - America/St_Vincent
+                  - America/Swift_Current
+                  - America/Tegucigalpa
+                  - America/Thule
+                  - America/Thunder_Bay
+                  - America/Tijuana
+                  - America/Toronto
+                  - America/Tortola
+                  - America/Vancouver
+                  - America/Virgin
+                  - America/Whitehorse
+                  - America/Winnipeg
+                  - America/Yakutat
+                  - America/Yellowknife
+                  - Antarctica/Casey
+                  - Antarctica/Davis
+                  - Antarctica/DumontDUrville
+                  - Antarctica/Macquarie
+                  - Antarctica/Mawson
+                  - Antarctica/McMurdo
+                  - Antarctica/Palmer
+                  - Antarctica/Rothera
+                  - Antarctica/South_Pole
+                  - Antarctica/Syowa
+                  - Antarctica/Troll
+                  - Antarctica/Vostok
+                  - Arctic/Longyearbyen
+                  - Asia/Aden
+                  - Asia/Almaty
+                  - Asia/Amman
+                  - Asia/Anadyr
+                  - Asia/Aqtau
+                  - Asia/Aqtobe
+                  - Asia/Ashgabat
+                  - Asia/Ashkhabad
+                  - Asia/Atyrau
+                  - Asia/Baghdad
+                  - Asia/Bahrain
+                  - Asia/Baku
+                  - Asia/Bangkok
+                  - Asia/Barnaul
+                  - Asia/Beirut
+                  - Asia/Bishkek
+                  - Asia/Brunei
+                  - Asia/Calcutta
+                  - Asia/Chita
+                  - Asia/Choibalsan
+                  - Asia/Chongqing
+                  - Asia/Chungking
+                  - Asia/Colombo
+                  - Asia/Dacca
+                  - Asia/Damascus
+                  - Asia/Dhaka
+                  - Asia/Dili
+                  - Asia/Dubai
+                  - Asia/Dushanbe
+                  - Asia/Famagusta
+                  - Asia/Gaza
+                  - Asia/Harbin
+                  - Asia/Hebron
+                  - Asia/Ho_Chi_Minh
+                  - Asia/Hong_Kong
+                  - Asia/Hovd
+                  - Asia/Irkutsk
+                  - Asia/Istanbul
+                  - Asia/Jakarta
+                  - Asia/Jayapura
+                  - Asia/Jerusalem
+                  - Asia/Kabul
+                  - Asia/Kamchatka
+                  - Asia/Karachi
+                  - Asia/Kashgar
+                  - Asia/Kathmandu
+                  - Asia/Katmandu
+                  - Asia/Khandyga
+                  - Asia/Kolkata
+                  - Asia/Krasnoyarsk
+                  - Asia/Kuala_Lumpur
+                  - Asia/Kuching
+                  - Asia/Kuwait
+                  - Asia/Macao
+                  - Asia/Macau
+                  - Asia/Magadan
+                  - Asia/Makassar
+                  - Asia/Manila
+                  - Asia/Muscat
+                  - Asia/Nicosia
+                  - Asia/Novokuznetsk
+                  - Asia/Novosibirsk
+                  - Asia/Omsk
+                  - Asia/Oral
+                  - Asia/Phnom_Penh
+                  - Asia/Pontianak
+                  - Asia/Pyongyang
+                  - Asia/Qatar
+                  - Asia/Qostanay
+                  - Asia/Qyzylorda
+                  - Asia/Rangoon
+                  - Asia/Riyadh
+                  - Asia/Saigon
+                  - Asia/Sakhalin
+                  - Asia/Samarkand
+                  - Asia/Seoul
+                  - Asia/Shanghai
+                  - Asia/Singapore
+                  - Asia/Srednekolymsk
+                  - Asia/Taipei
+                  - Asia/Tashkent
+                  - Asia/Tbilisi
+                  - Asia/Tehran
+                  - Asia/Tel_Aviv
+                  - Asia/Thimbu
+                  - Asia/Thimphu
+                  - Asia/Tokyo
+                  - Asia/Tomsk
+                  - Asia/Ujung_Pandang
+                  - Asia/Ulaanbaatar
+                  - Asia/Ulan_Bator
+                  - Asia/Urumqi
+                  - Asia/Ust-Nera
+                  - Asia/Vientiane
+                  - Asia/Vladivostok
+                  - Asia/Yakutsk
+                  - Asia/Yangon
+                  - Asia/Yekaterinburg
+                  - Asia/Yerevan
+                  - Atlantic/Azores
+                  - Atlantic/Bermuda
+                  - Atlantic/Canary
+                  - Atlantic/Cape_Verde
+                  - Atlantic/Faeroe
+                  - Atlantic/Faroe
+                  - Atlantic/Jan_Mayen
+                  - Atlantic/Madeira
+                  - Atlantic/Reykjavik
+                  - Atlantic/South_Georgia
+                  - Atlantic/St_Helena
+                  - Atlantic/Stanley
+                  - Australia/ACT
+                  - Australia/Adelaide
+                  - Australia/Brisbane
+                  - Australia/Broken_Hill
+                  - Australia/Canberra
+                  - Australia/Currie
+                  - Australia/Darwin
+                  - Australia/Eucla
+                  - Australia/Hobart
+                  - Australia/LHI
+                  - Australia/Lindeman
+                  - Australia/Lord_Howe
+                  - Australia/Melbourne
+                  - Australia/NSW
+                  - Australia/North
+                  - Australia/Perth
+                  - Australia/Queensland
+                  - Australia/South
+                  - Australia/Sydney
+                  - Australia/Tasmania
+                  - Australia/Victoria
+                  - Australia/West
+                  - Australia/Yancowinna
+                  - Brazil/Acre
+                  - Brazil/DeNoronha
+                  - Brazil/East
+                  - Brazil/West
+                  - CET
+                  - CST6CDT
+                  - Canada/Atlantic
+                  - Canada/Central
+                  - Canada/Eastern
+                  - Canada/Mountain
+                  - Canada/Newfoundland
+                  - Canada/Pacific
+                  - Canada/Saskatchewan
+                  - Canada/Yukon
+                  - Chile/Continental
+                  - Chile/EasterIsland
+                  - Cuba
+                  - EET
+                  - EST
+                  - EST5EDT
+                  - Egypt
+                  - Eire
+                  - Etc/GMT
+                  - Etc/GMT+0
+                  - Etc/GMT+1
+                  - Etc/GMT+10
+                  - Etc/GMT+11
+                  - Etc/GMT+12
+                  - Etc/GMT+2
+                  - Etc/GMT+3
+                  - Etc/GMT+4
+                  - Etc/GMT+5
+                  - Etc/GMT+6
+                  - Etc/GMT+7
+                  - Etc/GMT+8
+                  - Etc/GMT+9
+                  - Etc/GMT-0
+                  - Etc/GMT-1
+                  - Etc/GMT-10
+                  - Etc/GMT-11
+                  - Etc/GMT-12
+                  - Etc/GMT-13
+                  - Etc/GMT-14
+                  - Etc/GMT-2
+                  - Etc/GMT-3
+                  - Etc/GMT-4
+                  - Etc/GMT-5
+                  - Etc/GMT-6
+                  - Etc/GMT-7
+                  - Etc/GMT-8
+                  - Etc/GMT-9
+                  - Etc/GMT0
+                  - Etc/Greenwich
+                  - Etc/UCT
+                  - Etc/UTC
+                  - Etc/Universal
+                  - Etc/Zulu
+                  - Europe/Amsterdam
+                  - Europe/Andorra
+                  - Europe/Astrakhan
+                  - Europe/Athens
+                  - Europe/Belfast
+                  - Europe/Belgrade
+                  - Europe/Berlin
+                  - Europe/Bratislava
+                  - Europe/Brussels
+                  - Europe/Bucharest
+                  - Europe/Budapest
+                  - Europe/Busingen
+                  - Europe/Chisinau
+                  - Europe/Copenhagen
+                  - Europe/Dublin
+                  - Europe/Gibraltar
+                  - Europe/Guernsey
+                  - Europe/Helsinki
+                  - Europe/Isle_of_Man
+                  - Europe/Istanbul
+                  - Europe/Jersey
+                  - Europe/Kaliningrad
+                  - Europe/Kiev
+                  - Europe/Kirov
+                  - Europe/Kyiv
+                  - Europe/Lisbon
+                  - Europe/Ljubljana
+                  - Europe/London
+                  - Europe/Luxembourg
+                  - Europe/Madrid
+                  - Europe/Malta
+                  - Europe/Mariehamn
+                  - Europe/Minsk
+                  - Europe/Monaco
+                  - Europe/Moscow
+                  - Europe/Nicosia
+                  - Europe/Oslo
+                  - Europe/Paris
+                  - Europe/Podgorica
+                  - Europe/Prague
+                  - Europe/Riga
+                  - Europe/Rome
+                  - Europe/Samara
+                  - Europe/San_Marino
+                  - Europe/Sarajevo
+                  - Europe/Saratov
+                  - Europe/Simferopol
+                  - Europe/Skopje
+                  - Europe/Sofia
+                  - Europe/Stockholm
+                  - Europe/Tallinn
+                  - Europe/Tirane
+                  - Europe/Tiraspol
+                  - Europe/Ulyanovsk
+                  - Europe/Uzhgorod
+                  - Europe/Vaduz
+                  - Europe/Vatican
+                  - Europe/Vienna
+                  - Europe/Vilnius
+                  - Europe/Volgograd
+                  - Europe/Warsaw
+                  - Europe/Zagreb
+                  - Europe/Zaporozhye
+                  - Europe/Zurich
+                  - Factory
+                  - GB
+                  - GB-Eire
+                  - GMT
+                  - GMT+0
+                  - GMT-0
+                  - GMT0
+                  - Greenwich
+                  - HST
+                  - Hongkong
+                  - Iceland
+                  - Indian/Antananarivo
+                  - Indian/Chagos
+                  - Indian/Christmas
+                  - Indian/Cocos
+                  - Indian/Comoro
+                  - Indian/Kerguelen
+                  - Indian/Mahe
+                  - Indian/Maldives
+                  - Indian/Mauritius
+                  - Indian/Mayotte
+                  - Indian/Reunion
+                  - Iran
+                  - Israel
+                  - Jamaica
+                  - Japan
+                  - Kwajalein
+                  - Libya
+                  - MET
+                  - MST
+                  - MST7MDT
+                  - Mexico/BajaNorte
+                  - Mexico/BajaSur
+                  - Mexico/General
+                  - NZ
+                  - NZ-CHAT
+                  - Navajo
+                  - PRC
+                  - PST8PDT
+                  - Pacific/Apia
+                  - Pacific/Auckland
+                  - Pacific/Bougainville
+                  - Pacific/Chatham
+                  - Pacific/Chuuk
+                  - Pacific/Easter
+                  - Pacific/Efate
+                  - Pacific/Enderbury
+                  - Pacific/Fakaofo
+                  - Pacific/Fiji
+                  - Pacific/Funafuti
+                  - Pacific/Galapagos
+                  - Pacific/Gambier
+                  - Pacific/Guadalcanal
+                  - Pacific/Guam
+                  - Pacific/Honolulu
+                  - Pacific/Johnston
+                  - Pacific/Kanton
+                  - Pacific/Kiritimati
+                  - Pacific/Kosrae
+                  - Pacific/Kwajalein
+                  - Pacific/Majuro
+                  - Pacific/Marquesas
+                  - Pacific/Midway
+                  - Pacific/Nauru
+                  - Pacific/Niue
+                  - Pacific/Norfolk
+                  - Pacific/Noumea
+                  - Pacific/Pago_Pago
+                  - Pacific/Palau
+                  - Pacific/Pitcairn
+                  - Pacific/Pohnpei
+                  - Pacific/Ponape
+                  - Pacific/Port_Moresby
+                  - Pacific/Rarotonga
+                  - Pacific/Saipan
+                  - Pacific/Samoa
+                  - Pacific/Tahiti
+                  - Pacific/Tarawa
+                  - Pacific/Tongatapu
+                  - Pacific/Truk
+                  - Pacific/Wake
+                  - Pacific/Wallis
+                  - Pacific/Yap
+                  - Poland
+                  - Portugal
+                  - ROC
+                  - ROK
+                  - Singapore
+                  - Turkey
+                  - UCT
+                  - US/Alaska
+                  - US/Aleutian
+                  - US/Arizona
+                  - US/Central
+                  - US/East-Indiana
+                  - US/Eastern
+                  - US/Hawaii
+                  - US/Indiana-Starke
+                  - US/Michigan
+                  - US/Mountain
+                  - US/Pacific
+                  - US/Samoa
+                  - UTC
+                  - Universal
+                  - W-SU
+                  - WET
+                  - Zulu
+                  - localtime
+                  type: string
+                num_bonus_submissions:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                total_submission_limit:
+                  description: "The maximum number of times a Group can submit to\n\
+                    \            this Project EVER."
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                allow_late_days:
+                  description: "Whether to allow the use of late days for submitting\n\
+                    \            past the deadline."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ultimate_submission_policy:
+                  description: "The \"ultimate\" submission for a group is the one\n\
+                    \            that will be used for final grading. This field specifies\n\
+                    \            how the ultimate submission should be determined."
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - most_recent
+                  - best_basic_score
+                  - best
+                  type: string
+                hide_ultimate_submission_fdbk:
+                  description: "A hard override that indicates that ultimate\n   \
+                    \         submission feedback should not be shown, even if the\n\
+                    \            appropriate criteria are met."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                instructor_files:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InstructorFile'
+                expected_student_files:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ExpectedStudentFile'
+                has_handgrading_rubric:
+                  description: Whether this project has a handgrading rubric.
+                  readOnly: true
+                  type: boolean
+                send_email_on_submission_received:
+                  description: "If True, users will receive a confirmation email\n\
+                    \            every time a submission of theirs is recorded in\
+                    \ the\n            database."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                send_email_on_non_deferred_tests_finished:
+                  description: "If True, users will receive a confirmation email\n\
+                    \            once all non-deferred test cases for their submission\
+                    \ are\n            finished grading."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                use_honor_pledge:
+                  description: "If True, then the frontend website should require\n\
+                    \            students to acknowledge an honor pledge. The text\
+                    \ of the\n            honor pledge is stored in honor_pledge_text."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                honor_pledge_text:
+                  description: The text of the honor pledge to display.
+                  nullable: false
+                  readOnly: false
+                  type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+      tags:
+      - projects
+    delete:
+      operationId: deleteProject
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - projects
+  /api/projects/{id}/num_queued_submissions/:
+    get:
+      operationId: getNumQueuedSubmissions
+      description: The number of submissions for this project with grading status
+        "queued".
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: integer
+          description: ''
+      tags:
+      - projects
+      - submissions
+  /api/projects/{id}/instructor_files/:
+    get:
+      operationId: listInstructorFiles
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InstructorFile'
+          description: ''
+      tags:
+      - instructor_files
+    post:
+      operationId: createInstructorFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file_obj:
+                  type: string
+                  format: binary
+                  description: The form-encoded file.
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstructorFile'
+          description: ''
+      tags:
+      - instructor_files
+  /api/instructor_files/{id}/:
+    get:
+      operationId: getInstructorFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstructorFile'
+          description: ''
+      tags:
+      - instructor_files
+    patch:
+      operationId: updateInstructorFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                project:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                name:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                size:
+                  description: ''
+                  readOnly: true
+                  type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstructorFile'
+          description: ''
+      tags:
+      - instructor_files
+    delete:
+      operationId: deleteInstructorFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - instructor_files
+  /api/instructor_files/{id}/content/:
+    get:
+      operationId: getInstructorFileContent
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - instructor_files
+    put:
+      operationId: setInstructorFileContent
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file_obj:
+                  type: string
+                  format: binary
+                  description: The form-encoded file.
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstructorFile'
+          description: ''
+      tags:
+      - instructor_files
+  /api/projects/{id}/expected_student_files/:
+    get:
+      operationId: listExpectedStudentFiles
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExpectedStudentFile'
+          description: ''
+      tags:
+      - expected_student_files
+    post:
+      operationId: createExpectedStudentFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                project:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                pattern:
+                  description: "A shell-style file pattern suitable for\n        \
+                    \    use with Python's fnmatch.fnmatch()\n            function\
+                    \ (https://docs.python.org/3.5/library/fnmatch.html)\n       \
+                    \     This string must be a legal UNIX filename and may not be\n\
+                    \            '..' or '.'.\n            NOTE: Patterns for a given\
+                    \ project must not overlap,\n                otherwise the behavior\
+                    \ is undefined."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                min_num_matches:
+                  description: "The minimum number of submitted student files that\n\
+                    \            should match the pattern. Must be non-negative."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                max_num_matches:
+                  description: "The maximum number of submitted student files that\n\
+                    \            can match the pattern. Must be >= min_num_matches"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+              required:
+              - project
+              - pattern
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExpectedStudentFile'
+          description: ''
+      tags:
+      - expected_student_files
+  /api/expected_student_files/{id}/:
+    get:
+      operationId: getExpectedStudentFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExpectedStudentFile'
+          description: ''
+      tags:
+      - expected_student_files
+    patch:
+      operationId: updateExpectedStudentFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                project:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                pattern:
+                  description: "A shell-style file pattern suitable for\n        \
+                    \    use with Python's fnmatch.fnmatch()\n            function\
+                    \ (https://docs.python.org/3.5/library/fnmatch.html)\n       \
+                    \     This string must be a legal UNIX filename and may not be\n\
+                    \            '..' or '.'.\n            NOTE: Patterns for a given\
+                    \ project must not overlap,\n                otherwise the behavior\
+                    \ is undefined."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                min_num_matches:
+                  description: "The minimum number of submitted student files that\n\
+                    \            should match the pattern. Must be non-negative."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                max_num_matches:
+                  description: "The maximum number of submitted student files that\n\
+                    \            can match the pattern. Must be >= min_num_matches"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExpectedStudentFile'
+          description: ''
+      tags:
+      - expected_student_files
+    delete:
+      operationId: deleteExpectedStudentFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - expected_student_files
+  /api/projects/{id}/group_invitations/:
+    get:
+      operationId: listGroupInvitations
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GroupInvitation'
+          description: ''
+      tags:
+      - group_invitations
+    post:
+      operationId: createGroupInvitation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                recipient_usernames:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupInvitation'
+          description: ''
+      tags:
+      - group_invitations
+  /api/group_invitations/{id}/:
+    get:
+      operationId: getGroupInvitation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupInvitation'
+          description: ''
+      tags:
+      - group_invitations
+    delete:
+      operationId: deleteGroupInvitation
+      description: Revoke or reject this invitation.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - group_invitations
+  /api/projects/{project_pk}/groups/:
+    get:
+      operationId: listGroups
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - groups
+    post:
+      operationId: createGroup
+      description: 'Create a new group with the specified members.
+
+        Size restrictions are ignored.
+
+        Available to admins only.'
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_names:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - groups
+  /api/groups/{id}/:
+    get:
+      operationId: getGroup
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - groups
+    patch:
+      operationId: updateGroup
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                member_names:
+                  type: array
+                  items:
+                    type: string
+                    format: username
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - groups
+    delete:
+      operationId: pseudoDeleteGroup
+      description: '"Deletes" a group by removing all of its members. Each group
+
+        member is replaced with a dummy user whose username contains
+
+        the group''s pk and the original username. This allows "deleted"
+
+        groups to be easily viewable and recoverable by the user.'
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - groups
+  /api/groups/{id}/ultimate_submission/:
+    get:
+      operationId: getUltimateSubmissionForGroup
+      description: "Permissions details:\n- The normal group and submission viewing\
+        \ permissions apply\n  first.\n- Staff members can always view their own ultimate\
+        \ submission.\n- Staff members can only view student and other staff ultimate\n\
+        \  submissions if the project closing time has passed.\n- If the project closing\
+        \ time has passed, staff can view student\n  and other staff ultimate submissions\
+        \ regardless of whether\n  ultimate submissions are marked as hidden.\n- Students\
+        \ can view their ultimate submissions as long as the\n  closing time has passed\
+        \ and ultimate submissions are not\n  overridden as being hidden."
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
+          description: ''
+      tags:
+      - groups
+      - submissions
+  /api/groups/{id}/submissions/:
+    get:
+      operationId: listSubmissions
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Submission'
+          description: ''
+      tags:
+      - submissions
+    post:
+      operationId: createSubmission
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                submitted_files:
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+        required: true
+        description: The files being submitted, as multipart/form-data.
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
+          description: ''
+      tags:
+      - submissions
+  /api/submissions/{id}/:
+    get:
+      operationId: getSubmission
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
+          description: ''
+      tags:
+      - submissions
+    patch:
+      operationId: updateSubmission
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                group:
+                  description: "The SubmissionGroup that this submission belongs to.\
+                    \ Note\n            that this field indirectly links this Submission\
+                    \ object to a\n            Project.\n            This field is\
+                    \ REQUIRED."
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                timestamp:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                submitter:
+                  description: The name of the user who made this submission
+                  nullable: false
+                  readOnly: true
+                  type: string
+                submitted_filenames:
+                  description: "The names of files that were submitted,\n        \
+                    \             excluding those that were discarded."
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: string
+                discarded_files:
+                  description: The names of files that were discarded when this Submission
+                    was created.
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: string
+                missing_files:
+                  description: "Stores missing filenames and the additional number\n\
+                    \            of files needed to satisfy a file pattern requirement.\n\
+                    \            Stored as key-value pairs of the form:\n        \
+                    \    {pattern: num_additional_needed}"
+                  nullable: false
+                  readOnly: true
+                  type: object
+                status:
+                  description: "The grading status of this submission see\n      \
+                    \      Submission.GradingStatus for details on allowed values."
+                  nullable: false
+                  readOnly: true
+                  enum:
+                  - received
+                  - queued
+                  - being_graded
+                  - waiting_for_deferred
+                  - finished_grading
+                  - removed_from_queue
+                  - rejected
+                  - error
+                  type: string
+                is_past_daily_limit:
+                  description: Whether this submission is past the daily submission
+                    limit.
+                  nullable: false
+                  readOnly: true
+                  type: boolean
+                is_bonus_submission:
+                  description: "When True, indicates that the group that made this\n\
+                    \            submission should be able to request normal feedback\
+                    \ for\n            this submission's results.\n            Note:\
+                    \ If this field is True, is_past_daily_limit should be\n     \
+                    \       False."
+                  nullable: false
+                  readOnly: true
+                  type: boolean
+                count_towards_total_limit:
+                  description: Whether this submission should count towards the total
+                    submission limit.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                does_not_count_for:
+                  description: "A list of users for whom this submission will NOT\n\
+                    \            count as their final graded submission. Users are\
+                    \ added to\n            this list if they are out of late days\
+                    \ and another group\n            member (who still has late days\
+                    \ remaining) uses their own\n            late day to submit."
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: string
+                position_in_queue:
+                  description: "Returns this submission's position in the queue of\
+                    \ submissions\n        to be graded for the associated project."
+                  readOnly: true
+                  type: integer
+                grading_start_time:
+                  description: The time that the submission was marked as being_graded.Can
+                    be used to calculate time spent in queue.
+                  nullable: true
+                  readOnly: true
+                  type: string
+                  format: date-time
+                non_deferred_grading_end_time:
+                  description: The time that the submission was marked as waiting_for_deferred.Can
+                    be used to calculate time spent grading non-deferred tests.
+                  nullable: true
+                  readOnly: true
+                  type: string
+                  format: date-time
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
+          description: ''
+      tags:
+      - submissions
+  /api/submissions/{id}/file/:
+    get:
+      operationId: getSubmittedFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: filename
+        in: query
+        description: The name of the file to return.
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: The file content.
+      tags:
+      - submissions
+  /api/submission_timings/:
+    get:
+      operationId: listSubmissionTimings
+      description: 'Superusers only. Load information about how long submissions
+
+        spent in the queue or being graded.'
+      parameters:
+      - name: since
+        in: query
+        description: Return all submissions created after this time. Defaults to 24
+          hours before the current time
+        schema:
+          type: string
+          format: date-time
+      - name: until
+        in: query
+        description: Return all submissions created before this time. Defaults to
+          the current time
+        schema:
+          type: string
+          format: date-time
+      - $ref: '#/components/parameters/page'
+      - name: page_size
+        in: query
+        description: The page size. Maximum value is 1000
+        schema:
+          type: integer
+          default: 500
+          maximum: 1000
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: url
+                  previous:
+                    type: string
+                    format: url
+                  results:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        project_id:
+                          type: integer
+                        timestamp:
+                          type: string
+                          format: datetime
+                        submitter:
+                          type: strength
+                        status:
+                          type: string
+                          enum:
+                          - received
+                          - queued
+                          - being_graded
+                          - waiting_for_deferred
+                          - finished_grading
+                          - removed_from_queue
+                          - rejected
+                          - error
+                        error_msg:
+                          type: string
+                        grading_start_time:
+                          type: string
+                          format: datetime
+                        non_deferred_grading_end_time:
+                          type: string
+                          format: datetime
+      tags:
+      - submissions
+  /api/sandbox_docker_images/:
+    get:
+      operationId: listGlobalSandboxDockerImages
+      description: Lists all global sandbox images (ones that don't belong to a course).
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SandboxDockerImage'
+          description: ''
+      tags:
+      - sandbox_docker_images
+    post:
+      operationId: createGlobalSandboxDockerImage
+      description: Build a new global sandbox image.
+      parameters: []
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  description: The form-encoded files. One file must be named "Dockerfile"
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: The build task has been started.
+      tags:
+      - sandbox_docker_images
+  /api/courses/{id}/sandbox_docker_images/:
+    get:
+      operationId: listSandboxDockerImagesForCourse
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SandboxDockerImage'
+          description: ''
+      tags:
+      - sandbox_docker_images
+    post:
+      operationId: createSandboxDockerImageForCourse
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  description: The form-encoded files. One file must be named "Dockerfile"
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: The build task has been started.
+      tags:
+      - sandbox_docker_images
+  /api/image_build_tasks/:
+    get:
+      operationId: listGlobalBuildSandboxDockerImageTasks
+      description: List all global (not belonging to a course) image build tasks.
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: ''
+      tags:
+      - sandbox_docker_images
+  /api/courses/{id}/image_build_tasks/:
+    get:
+      operationId: listBuildSandboxDockerImageTasksForCourse
+      description: List all image build tasks for the specified course.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: ''
+      tags:
+      - sandbox_docker_images
+  /api/image_build_tasks/{id}/:
+    get:
+      operationId: getBuildSandboxDockerImageTask
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: ''
+      tags:
+      - sandbox_docker_images
+  /api/image_build_tasks/{id}/output/:
+    get:
+      operationId: getBuildSandboxDockerImageTaskOutput
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - sandbox_docker_images
+  /api/image_build_tasks/{id}/files/:
+    get:
+      operationId: getBuildSandboxDockerImageTaskFiles
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+          description: A zip archive of the files included in the build.
+      tags:
+      - sandbox_docker_images
+  /api/sandbox_docker_images/{id}/:
+    get:
+      operationId: getSandboxDockerImage
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxDockerImage'
+          description: ''
+      tags:
+      - sandbox_docker_images
+    patch:
+      operationId: updateSandboxDockerImage
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                display_name:
+                  description: "A human-readable name for this sandbox image.\n  \
+                    \                   Must be unique among images belonging to a\
+                    \ course.\n                     This field is required."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                course:
+                  description: The course this image is associated with.
+                  nullable: true
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SandboxDockerImage'
+          description: ''
+      tags:
+      - sandbox_docker_images
+    delete:
+      operationId: deleteSandboxDockerImage
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - sandbox_docker_images
+  /api/projects/{project_pk}/ag_test_suites/:
+    get:
+      operationId: listAGTestSuites
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AGTestSuite'
+          description: ''
+      tags:
+      - ag_test_suites
+    post:
+      operationId: createAGTestSuite
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this suite.\n          \
+                    \           Must be non-empty and non-null.\n                \
+                    \     Must be unique among suites that belong to the same project.\n\
+                    \                     This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                project:
+                  description: "The project this suite belongs to.\n             \
+                    \                                This field is REQUIRED."
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                instructor_files_needed:
+                  description: "The project files that will be copied into the sandbox\
+                    \ before the suite's\n                     tests are run."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InstructorFile'
+                read_only_instructor_files:
+                  description: "When True, project files needed for this suite will\
+                    \ be read-only when this\n                     suite is run."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                student_files_needed:
+                  description: "Student-submitted files matching these patterns will\
+                    \ be copied into the\n                     sandbox before the\
+                    \ suite's tests are run."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ExpectedStudentFile'
+                ag_test_cases:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/AGTestCase'
+                setup_suite_cmd:
+                  description: "A command to be run before this suite's tests are\
+                    \ run.\n                     This command is only run once at\
+                    \ the beginning of the suite.\n                     This command\
+                    \ will be run after the student and project files\n          \
+                    \           have been added to the sandbox.\n                \
+                    \     If this field is empty, then no setup command will be run."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                setup_suite_cmd_name:
+                  description: The name of this suite's setup command.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                reject_submission_if_setup_fails:
+                  description: "When this field is True and the suite has a setup\
+                    \ command,\n            the submission will be rejected if that\
+                    \ setup command fails.\n            This field is only allowed\
+                    \ to be True for the first non-deferred AGTestSuite\n        \
+                    \    (order specified by Project.get_agtestsuite_order()) of the\
+                    \ Project."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                sandbox_docker_image:
+                  description: The sandbox docker image to use for running this suite.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/SandboxDockerImage'
+                allow_network_access:
+                  description: "Specifies whether the sandbox should allow commands\
+                    \ run inside of it to\n                     make network calls\
+                    \ outside of the sandbox."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                deferred:
+                  description: "If true, this test suite can be graded asynchronously.\
+                    \ Deferred suites that\n                     have yet to be graded\
+                    \ do not prevent members of a group from submitting\n        \
+                    \             again."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                normal_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+              required:
+              - name
+              - project
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestSuite'
+          description: ''
+      tags:
+      - ag_test_suites
+  /api/projects/{project_pk}/ag_test_suites/order/:
+    get:
+      operationId: getAGTestSuiteOrder
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - ag_test_suites
+    put:
+      operationId: setAGTestSuiteOrder
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: id
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - ag_test_suites
+  /api/ag_test_suites/{id}/:
+    get:
+      operationId: getAGTestSuite
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestSuite'
+          description: ''
+      tags:
+      - ag_test_suites
+    patch:
+      operationId: updateAGTestSuite
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this suite.\n          \
+                    \           Must be non-empty and non-null.\n                \
+                    \     Must be unique among suites that belong to the same project.\n\
+                    \                     This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                project:
+                  description: "The project this suite belongs to.\n             \
+                    \                                This field is REQUIRED."
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                instructor_files_needed:
+                  description: "The project files that will be copied into the sandbox\
+                    \ before the suite's\n                     tests are run."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InstructorFile'
+                read_only_instructor_files:
+                  description: "When True, project files needed for this suite will\
+                    \ be read-only when this\n                     suite is run."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                student_files_needed:
+                  description: "Student-submitted files matching these patterns will\
+                    \ be copied into the\n                     sandbox before the\
+                    \ suite's tests are run."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ExpectedStudentFile'
+                ag_test_cases:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/AGTestCase'
+                setup_suite_cmd:
+                  description: "A command to be run before this suite's tests are\
+                    \ run.\n                     This command is only run once at\
+                    \ the beginning of the suite.\n                     This command\
+                    \ will be run after the student and project files\n          \
+                    \           have been added to the sandbox.\n                \
+                    \     If this field is empty, then no setup command will be run."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                setup_suite_cmd_name:
+                  description: The name of this suite's setup command.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                reject_submission_if_setup_fails:
+                  description: "When this field is True and the suite has a setup\
+                    \ command,\n            the submission will be rejected if that\
+                    \ setup command fails.\n            This field is only allowed\
+                    \ to be True for the first non-deferred AGTestSuite\n        \
+                    \    (order specified by Project.get_agtestsuite_order()) of the\
+                    \ Project."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                sandbox_docker_image:
+                  description: The sandbox docker image to use for running this suite.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/SandboxDockerImage'
+                allow_network_access:
+                  description: "Specifies whether the sandbox should allow commands\
+                    \ run inside of it to\n                     make network calls\
+                    \ outside of the sandbox."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                deferred:
+                  description: "If true, this test suite can be graded asynchronously.\
+                    \ Deferred suites that\n                     have yet to be graded\
+                    \ do not prevent members of a group from submitting\n        \
+                    \             again."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                normal_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestSuite'
+          description: ''
+      tags:
+      - ag_test_suites
+    delete:
+      operationId: deleteAGTestSuite
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - ag_test_suites
+  /api/ag_test_suites/{ag_test_suite_pk}/ag_test_cases/:
+    get:
+      operationId: listAGTestCases
+      description: ''
+      parameters:
+      - name: ag_test_suite_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AGTestCase'
+          description: ''
+      tags:
+      - ag_test_cases
+    post:
+      operationId: createAGTestCase
+      description: ''
+      parameters:
+      - name: ag_test_suite_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this autograder test.\n\
+                    \                     Must be non-empty and non-null.\n      \
+                    \               Must be unique among autograder tests that belong\
+                    \ to the same suite.\n                     This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                ag_test_suite:
+                  description: "The suite this autograder test belongs to.\n     \
+                    \                This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                  format: id
+                ag_test_commands:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/AGTestCommand'
+                normal_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+              required:
+              - name
+              - ag_test_suite
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestCase'
+          description: ''
+      tags:
+      - ag_test_cases
+  /api/ag_test_suites/{ag_test_suite_pk}/ag_test_cases/order/:
+    get:
+      operationId: getAGTestCaseOrder
+      description: ''
+      parameters:
+      - name: ag_test_suite_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - ag_test_cases
+    put:
+      operationId: setAGTestCaseOrder
+      description: ''
+      parameters:
+      - name: ag_test_suite_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: id
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - ag_test_cases
+  /api/ag_test_cases/{id}/:
+    get:
+      operationId: getAGTestCase
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestCase'
+          description: ''
+      tags:
+      - ag_test_cases
+    patch:
+      operationId: updateAGTestCase
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this autograder test.\n\
+                    \                     Must be non-empty and non-null.\n      \
+                    \               Must be unique among autograder tests that belong\
+                    \ to the same suite.\n                     This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                ag_test_suite:
+                  description: "The suite this autograder test belongs to.\n     \
+                    \                This field is REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                  format: id
+                ag_test_commands:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/AGTestCommand'
+                normal_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestCase'
+          description: ''
+      tags:
+      - ag_test_cases
+    delete:
+      operationId: deleteAGTestCase
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - ag_test_cases
+  /api/ag_test_cases/{ag_test_case_pk}/ag_test_commands/:
+    get:
+      operationId: listAGTestCommands
+      description: ''
+      parameters:
+      - name: ag_test_case_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AGTestCommand'
+          description: ''
+      tags:
+      - ag_test_commands
+    post:
+      operationId: createAGTestCommand
+      description: ''
+      parameters:
+      - name: ag_test_case_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this command.\n        \
+                    \                 Must be non-empty and non-null.\n          \
+                    \               Must be unique among commands that belong to the\
+                    \ same autograder test.\n                         This field is\
+                    \ REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                ag_test_case:
+                  description: The AGTestCase that this command belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                cmd:
+                  description: "A string containing the command to be run.\n     \
+                    \                Note: This string will be inserted into ['bash',\
+                    \ '-c', <cmd>]\n                        in order to be executed.\n\
+                    \                     Note: This string defaults to the \"true\"\
+                    \ command\n                     (which does nothing and returns\
+                    \ 0) so that AGCommands are\n                     default-creatable."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                stdin_source:
+                  description: Specifies what kind of source stdin will be redirected
+                    from.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - text
+                  - instructor_file
+                  - setup_stdout
+                  - setup_stderr
+                  type: string
+                stdin_text:
+                  description: "A string whose contents should be redirected to the\
+                    \ stdin of this command.\n                     This value is used\
+                    \ when stdin_source is StdinSource.text and is ignored\n     \
+                    \                otherwise."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                stdin_instructor_file:
+                  description: "An InstructorFile whose contents should be redirected\
+                    \ to the stdin of this\n                     command. This value\
+                    \ is used when stdin_source is StdinSource.instructor_file\n \
+                    \                    and is ignored otherwise."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/InstructorFile'
+                expected_return_code:
+                  description: Specifies the command's expected return code.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - zero
+                  - nonzero
+                  type: string
+                expected_stdout_source:
+                  description: Specifies what kind of source this command's stdout
+                    should be compared to.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - text
+                  - instructor_file
+                  type: string
+                expected_stdout_text:
+                  description: "A string whose contents should be compared against\
+                    \ this command's stdout.\n                     This value is used\
+                    \ when expected_stdout_source is ExpectedOutputSource.text\n \
+                    \                    and is ignored otherwise."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                expected_stdout_instructor_file:
+                  description: "An InstructorFile whose contents should be compared\
+                    \ against this command's\n                     stdout. This value\
+                    \ is used (and may not be null) when expected_stdout_source\n\
+                    \                     is ExpectedOutputSource.instructor_file\
+                    \ and is ignored otherwise."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/InstructorFile'
+                expected_stderr_source:
+                  description: Specifies what kind of source this command's stderr
+                    should be compared to.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - text
+                  - instructor_file
+                  type: string
+                expected_stderr_text:
+                  description: "A string whose contents should be compared against\
+                    \ this command's stderr.\n                     This value is used\
+                    \ when expected_stderr_source is ExpectedOutputSource.text\n \
+                    \                    and is ignored otherwise."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                expected_stderr_instructor_file:
+                  description: "An InstructorFile whose contents should be compared\
+                    \ against this command's\n                     stderr. This value\
+                    \ is used (and may not be null) when expected_stderr_source\n\
+                    \                     is ExpectedOutputSource.instructor_file\
+                    \ and is ignored otherwise."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/InstructorFile'
+                ignore_case:
+                  description: Ignore case when checking output. Equivalent to diff
+                    -i
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ignore_whitespace:
+                  description: Ignore inline whitespace when checking output. Equivalent
+                    to diff -w
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ignore_whitespace_changes:
+                  description: Ignore whitespace changes when checking output. Equivalent
+                    to diff -b
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ignore_blank_lines:
+                  description: Ignore changes in blank lines when checking output.
+                    Equivalent to diff -B
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                points_for_correct_return_code:
+                  description: "The number of points to be awarded when this command\n\
+                    \                     produces the correct return_code"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                points_for_correct_stdout:
+                  description: "The number of points to be awarded when this command\n\
+                    \                     produces the correct stdout"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                points_for_correct_stderr:
+                  description: "The number of points to be awarded when this command\n\
+                    \                     produces the correct stderr"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                deduction_for_wrong_return_code:
+                  description: "The number of points to deduct when this command\n\
+                    \                     produces the wrong return code (this value\
+                    \ must be negative).\n                     Note: The total points\
+                    \ given for a single command may be negative,\n              \
+                    \       but the total points for an AGTestCase will be capped\
+                    \ at zero."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                deduction_for_wrong_stdout:
+                  description: "The number of points to deduct when this command\n\
+                    \                     produces the wrong stdout (this value must\
+                    \ be negative).\n                     Note: The total points given\
+                    \ for a single command may be negative,\n                    \
+                    \ but the total points for an AGTestCase will be capped at zero."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                deduction_for_wrong_stderr:
+                  description: "The number of points to deduct when this command\n\
+                    \                     produces the wrong stderr (this value must\
+                    \ be negative).\n                     Note: The total points given\
+                    \ for a single command may be negative,\n                    \
+                    \ but the total points for an AGTestCase will be capped at zero."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                normal_fdbk_config:
+                  description: Feedback settings for a normal Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                first_failed_test_normal_fdbk_config:
+                  description: "When non-null, specifies feedback to be given when\n\
+                    \                     this command is in the first test case that\
+                    \ failed\n                     within a suite."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: Feedback settings for an ultimate Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: Feedback settings for a Submission that is past the
+                    daily limit.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: Feedback settings for a staff member viewing a Submission
+                    from another group.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                time_limit:
+                  description: "The time limit in seconds to be placed on the command.\n\
+                    \            Must be > 0\n            Must be <= 90"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                use_virtual_memory_limit:
+                  description: "When set to false, the virtual memory limit will not\n\
+                    \            be applied to the command. Note that the sandbox\
+                    \ will still apply\n            a physical memory limit to all\
+                    \ commands run in the sandbox."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                virtual_memory_limit:
+                  description: "The maximum amount of virtual memory\n           \
+                    \ (in bytes) the command can use. Must be > 0.\n            Limiting\
+                    \ virtual memory can help produce cleaner\n            error messages\
+                    \ when the command uses too much memory. However, some programs\
+                    \ allocate\n            a large amount of virtual memory but use\
+                    \ very little *physical* memory. For these\n            kinds\
+                    \ of programs (e.g. Java programs), we recommend NOT limiting\
+                    \ virtual memory.\n            Note that physical memory usage\
+                    \ will still be limited for security reasons."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                block_process_spawn:
+                  description: When true, prevents the command from spawning child
+                    processes.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+              required:
+              - name
+              - ag_test_case
+              - cmd
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestCommand'
+          description: ''
+      tags:
+      - ag_test_commands
+  /api/ag_test_cases/{ag_test_case_pk}/ag_test_commands/order/:
+    get:
+      operationId: getAGTestCommandOrder
+      description: ''
+      parameters:
+      - name: ag_test_case_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - ag_test_commands
+    put:
+      operationId: setAGTestCommandOrder
+      description: ''
+      parameters:
+      - name: ag_test_case_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: id
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - ag_test_commands
+  /api/ag_test_commands/{id}/:
+    get:
+      operationId: getAGTestCommand
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestCommand'
+          description: ''
+      tags:
+      - ag_test_commands
+    patch:
+      operationId: updateAGTestCommand
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this command.\n        \
+                    \                 Must be non-empty and non-null.\n          \
+                    \               Must be unique among commands that belong to the\
+                    \ same autograder test.\n                         This field is\
+                    \ REQUIRED."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                ag_test_case:
+                  description: The AGTestCase that this command belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                cmd:
+                  description: "A string containing the command to be run.\n     \
+                    \                Note: This string will be inserted into ['bash',\
+                    \ '-c', <cmd>]\n                        in order to be executed.\n\
+                    \                     Note: This string defaults to the \"true\"\
+                    \ command\n                     (which does nothing and returns\
+                    \ 0) so that AGCommands are\n                     default-creatable."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                stdin_source:
+                  description: Specifies what kind of source stdin will be redirected
+                    from.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - text
+                  - instructor_file
+                  - setup_stdout
+                  - setup_stderr
+                  type: string
+                stdin_text:
+                  description: "A string whose contents should be redirected to the\
+                    \ stdin of this command.\n                     This value is used\
+                    \ when stdin_source is StdinSource.text and is ignored\n     \
+                    \                otherwise."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                stdin_instructor_file:
+                  description: "An InstructorFile whose contents should be redirected\
+                    \ to the stdin of this\n                     command. This value\
+                    \ is used when stdin_source is StdinSource.instructor_file\n \
+                    \                    and is ignored otherwise."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/InstructorFile'
+                expected_return_code:
+                  description: Specifies the command's expected return code.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - zero
+                  - nonzero
+                  type: string
+                expected_stdout_source:
+                  description: Specifies what kind of source this command's stdout
+                    should be compared to.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - text
+                  - instructor_file
+                  type: string
+                expected_stdout_text:
+                  description: "A string whose contents should be compared against\
+                    \ this command's stdout.\n                     This value is used\
+                    \ when expected_stdout_source is ExpectedOutputSource.text\n \
+                    \                    and is ignored otherwise."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                expected_stdout_instructor_file:
+                  description: "An InstructorFile whose contents should be compared\
+                    \ against this command's\n                     stdout. This value\
+                    \ is used (and may not be null) when expected_stdout_source\n\
+                    \                     is ExpectedOutputSource.instructor_file\
+                    \ and is ignored otherwise."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/InstructorFile'
+                expected_stderr_source:
+                  description: Specifies what kind of source this command's stderr
+                    should be compared to.
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - none
+                  - text
+                  - instructor_file
+                  type: string
+                expected_stderr_text:
+                  description: "A string whose contents should be compared against\
+                    \ this command's stderr.\n                     This value is used\
+                    \ when expected_stderr_source is ExpectedOutputSource.text\n \
+                    \                    and is ignored otherwise."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                expected_stderr_instructor_file:
+                  description: "An InstructorFile whose contents should be compared\
+                    \ against this command's\n                     stderr. This value\
+                    \ is used (and may not be null) when expected_stderr_source\n\
+                    \                     is ExpectedOutputSource.instructor_file\
+                    \ and is ignored otherwise."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/InstructorFile'
+                ignore_case:
+                  description: Ignore case when checking output. Equivalent to diff
+                    -i
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ignore_whitespace:
+                  description: Ignore inline whitespace when checking output. Equivalent
+                    to diff -w
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ignore_whitespace_changes:
+                  description: Ignore whitespace changes when checking output. Equivalent
+                    to diff -b
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                ignore_blank_lines:
+                  description: Ignore changes in blank lines when checking output.
+                    Equivalent to diff -B
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                points_for_correct_return_code:
+                  description: "The number of points to be awarded when this command\n\
+                    \                     produces the correct return_code"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                points_for_correct_stdout:
+                  description: "The number of points to be awarded when this command\n\
+                    \                     produces the correct stdout"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                points_for_correct_stderr:
+                  description: "The number of points to be awarded when this command\n\
+                    \                     produces the correct stderr"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                deduction_for_wrong_return_code:
+                  description: "The number of points to deduct when this command\n\
+                    \                     produces the wrong return code (this value\
+                    \ must be negative).\n                     Note: The total points\
+                    \ given for a single command may be negative,\n              \
+                    \       but the total points for an AGTestCase will be capped\
+                    \ at zero."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                deduction_for_wrong_stdout:
+                  description: "The number of points to deduct when this command\n\
+                    \                     produces the wrong stdout (this value must\
+                    \ be negative).\n                     Note: The total points given\
+                    \ for a single command may be negative,\n                    \
+                    \ but the total points for an AGTestCase will be capped at zero."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                deduction_for_wrong_stderr:
+                  description: "The number of points to deduct when this command\n\
+                    \                     produces the wrong stderr (this value must\
+                    \ be negative).\n                     Note: The total points given\
+                    \ for a single command may be negative,\n                    \
+                    \ but the total points for an AGTestCase will be capped at zero."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                normal_fdbk_config:
+                  description: Feedback settings for a normal Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                first_failed_test_normal_fdbk_config:
+                  description: "When non-null, specifies feedback to be given when\n\
+                    \                     this command is in the first test case that\
+                    \ failed\n                     within a suite."
+                  nullable: true
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: Feedback settings for an ultimate Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: Feedback settings for a Submission that is past the
+                    daily limit.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: Feedback settings for a staff member viewing a Submission
+                    from another group.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+                time_limit:
+                  description: "The time limit in seconds to be placed on the command.\n\
+                    \            Must be > 0\n            Must be <= 90"
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                use_virtual_memory_limit:
+                  description: "When set to false, the virtual memory limit will not\n\
+                    \            be applied to the command. Note that the sandbox\
+                    \ will still apply\n            a physical memory limit to all\
+                    \ commands run in the sandbox."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                virtual_memory_limit:
+                  description: "The maximum amount of virtual memory\n           \
+                    \ (in bytes) the command can use. Must be > 0.\n            Limiting\
+                    \ virtual memory can help produce cleaner\n            error messages\
+                    \ when the command uses too much memory. However, some programs\
+                    \ allocate\n            a large amount of virtual memory but use\
+                    \ very little *physical* memory. For these\n            kinds\
+                    \ of programs (e.g. Java programs), we recommend NOT limiting\
+                    \ virtual memory.\n            Note that physical memory usage\
+                    \ will still be limited for security reasons."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                block_process_spawn:
+                  description: When true, prevents the command from spawning child
+                    processes.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AGTestCommand'
+          description: ''
+      tags:
+      - ag_test_commands
+    delete:
+      operationId: deleteAGTestCommand
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - ag_test_commands
+  /api/projects/{project_pk}/mutation_test_suites/:
+    get:
+      operationId: listMutationTestSuites
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MutationTestSuite'
+          description: ''
+      tags:
+      - mutation_test_suites
+    post:
+      operationId: createMutationTestSuite
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this MutationTestSuite.\n\
+                    \                     Must be non-empty and non-null."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                project:
+                  description: The Project that this mutation test suite belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                instructor_files_needed:
+                  description: "The project files that will be copied into the sandbox\
+                    \ before the suite\n                     is graded."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InstructorFile'
+                read_only_instructor_files:
+                  description: "When True, project files needed for this suite will\
+                    \ be read-only when this\n                     suite is graded."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                student_files_needed:
+                  description: "Student-submitted files matching these patterns will\
+                    \ be copied into the\n                     sandbox before the\
+                    \ suite is graded."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ExpectedStudentFile'
+                buggy_impl_names:
+                  description: The names of buggy implementations that student tests
+                    should be run against.
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: string
+                use_setup_command:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                setup_command:
+                  description: "A command to be run after student and project files\
+                    \ have\n                     been added to the sandbox but before\
+                    \ any other commands are run.\n                     To indicate\
+                    \ that no setup command should be run,\n                     set\
+                    \ use_setup_command to False."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                get_student_test_names_command:
+                  description: "This required command should print out a list of student\n\
+                    \             test case names. The test case names should not\
+                    \ be wrapped\n             in quotes, even if the test names contain\
+                    \ spaces.\n             If test_name_discovery_whitespace_handling\
+                    \ is set to\n             'any_whitespace', the output of this\
+                    \ command will be parsed using\n             Python's str.split().\
+                    \ If set to 'newline', the output will\n             be parsed\
+                    \ using Python's str.splitlines(), and leading and trailing\n\
+                    \             whitespace will be stripped from each line."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                test_name_discovery_whitespace_handling:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - newline
+                  - any_whitespace
+                  type: string
+                max_num_student_tests:
+                  description: "The maximum number of test cases students are allowed\
+                    \ to submit.\n                     If more than this many tests\
+                    \ are discovered by the\n                     get_student_test_names_command,\
+                    \ test names will be discarded\n                     from the\
+                    \ end of that list."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                student_test_validity_check_command:
+                  description: "This command will be run once for each detected student\
+                    \ test case.\n                     An exit status of zero indicates\
+                    \ that a student test case is valid,\n                     whereas\
+                    \ a nonzero exit status indicates that a student test case\n \
+                    \                    is invalid.\n                     This command\
+                    \ must contain the placeholder ${student_test_name} at least once.\
+                    \ That\n                     placeholder will be replaced with\
+                    \ the name of the student test case\n                     that\
+                    \ is to be checked for validity."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                grade_buggy_impl_command:
+                  description: "This command will be run at least once for every buggy\
+                    \ implementation.\n            A nonzero exit status indicates\
+                    \ that the valid student tests exposed the\n            buggy\
+                    \ impl, whereas an exit status of zero indicates that the student\n\
+                    \            tests did not expose the buggy impl.\n\n        \
+                    \    This command must contain the placeholders ${buggy_impl_name}\n\
+                    \            and one of ${student_test_name} or ${all_valid_test_names}.\n\
+                    \            The placeholder ${buggy_impl_name} will be replaced\
+                    \ with the name of\n            the buggy impl that the student\
+                    \ test is being run against.\n            If the placeholder ${student_test_name}\
+                    \ is present,\n            it will be replaced with the name of\
+                    \ a single valid student test case,\n            and the command\
+                    \ will be run once for every (buggy implementation, valid test)\
+                    \ pair.\n            If the placeholder ${all_valid_test_names}\
+                    \ is present,\n            it will be replaced with the individually-quoted\
+                    \ names of all valid\n            student tests, and the command\
+                    \ will be run once for each buggy implementation.\n\n        \
+                    \    This latter approach can potentially reduce the runtime (e.g.,\
+                    \ by\n            reducing the number of times an interpreter\
+                    \ is invoked).\n            Note that you may need to specify\
+                    \ a higher time limit with this strategy--for\n            example,\
+                    \ if each individual test takes 1 second to run and running\n\
+                    \            10 tests at once takes 10 seconds, the time limit\
+                    \ will need to be\n            more than 10 seconds, otherwise\
+                    \ buggy impls could be erroneously\n            marked as exposed\
+                    \ due to the tests exceeding a low time limit."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                points_per_exposed_bug:
+                  description: "The number of points to be awarded per buggy implementation\
+                    \ exposed by\n                     the student test cases. This\
+                    \ field is limited to 4 digits total and a maximum\n         \
+                    \            of 2 decimal places."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                  format: float
+                max_points:
+                  description: An optional ceiling on the number of points to be awarded.
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                deferred:
+                  description: "If true, this mutation test suite can be graded asynchronously.\n\
+                    \                     Deferred suites that have yet to be graded\
+                    \ do not prevent members\n                     of a group from\
+                    \ submitting again."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                sandbox_docker_image:
+                  description: The sandbox docker image to use for running this suite.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/SandboxDockerImage'
+                allow_network_access:
+                  description: "Specifies whether the sandbox should allow commands\
+                    \ run inside of it to\n                     make network calls\
+                    \ outside of the sandbox."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                normal_fdbk_config:
+                  description: Feedback settings for a normal Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: Feedback settings for an ultimate Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: Feedback settings for a Submission that is past the
+                    daily limit.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: Feedback settings for a staff member viewing a Submission
+                    from another group.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+              required:
+              - name
+              - project
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationTestSuite'
+          description: ''
+      tags:
+      - mutation_test_suites
+  /api/projects/{project_pk}/mutation_test_suites/order/:
+    get:
+      operationId: getMutationTestSuiteOrder
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - mutation_test_suites
+    put:
+      operationId: setMutationTestSuiteOrder
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: id
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - mutation_test_suites
+  /api/mutation_test_suites/{id}/:
+    get:
+      operationId: getMutationTestSuite
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationTestSuite'
+          description: ''
+      tags:
+      - mutation_test_suites
+    patch:
+      operationId: updateMutationTestSuite
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                name:
+                  description: "The name used to identify this MutationTestSuite.\n\
+                    \                     Must be non-empty and non-null."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                project:
+                  description: The Project that this mutation test suite belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                instructor_files_needed:
+                  description: "The project files that will be copied into the sandbox\
+                    \ before the suite\n                     is graded."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/InstructorFile'
+                read_only_instructor_files:
+                  description: "When True, project files needed for this suite will\
+                    \ be read-only when this\n                     suite is graded."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                student_files_needed:
+                  description: "Student-submitted files matching these patterns will\
+                    \ be copied into the\n                     sandbox before the\
+                    \ suite is graded."
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ExpectedStudentFile'
+                buggy_impl_names:
+                  description: The names of buggy implementations that student tests
+                    should be run against.
+                  nullable: false
+                  readOnly: false
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: string
+                use_setup_command:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                setup_command:
+                  description: "A command to be run after student and project files\
+                    \ have\n                     been added to the sandbox but before\
+                    \ any other commands are run.\n                     To indicate\
+                    \ that no setup command should be run,\n                     set\
+                    \ use_setup_command to False."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                get_student_test_names_command:
+                  description: "This required command should print out a list of student\n\
+                    \             test case names. The test case names should not\
+                    \ be wrapped\n             in quotes, even if the test names contain\
+                    \ spaces.\n             If test_name_discovery_whitespace_handling\
+                    \ is set to\n             'any_whitespace', the output of this\
+                    \ command will be parsed using\n             Python's str.split().\
+                    \ If set to 'newline', the output will\n             be parsed\
+                    \ using Python's str.splitlines(), and leading and trailing\n\
+                    \             whitespace will be stripped from each line."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                test_name_discovery_whitespace_handling:
+                  description: ''
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - newline
+                  - any_whitespace
+                  type: string
+                max_num_student_tests:
+                  description: "The maximum number of test cases students are allowed\
+                    \ to submit.\n                     If more than this many tests\
+                    \ are discovered by the\n                     get_student_test_names_command,\
+                    \ test names will be discarded\n                     from the\
+                    \ end of that list."
+                  nullable: false
+                  readOnly: false
+                  type: integer
+                student_test_validity_check_command:
+                  description: "This command will be run once for each detected student\
+                    \ test case.\n                     An exit status of zero indicates\
+                    \ that a student test case is valid,\n                     whereas\
+                    \ a nonzero exit status indicates that a student test case\n \
+                    \                    is invalid.\n                     This command\
+                    \ must contain the placeholder ${student_test_name} at least once.\
+                    \ That\n                     placeholder will be replaced with\
+                    \ the name of the student test case\n                     that\
+                    \ is to be checked for validity."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                grade_buggy_impl_command:
+                  description: "This command will be run at least once for every buggy\
+                    \ implementation.\n            A nonzero exit status indicates\
+                    \ that the valid student tests exposed the\n            buggy\
+                    \ impl, whereas an exit status of zero indicates that the student\n\
+                    \            tests did not expose the buggy impl.\n\n        \
+                    \    This command must contain the placeholders ${buggy_impl_name}\n\
+                    \            and one of ${student_test_name} or ${all_valid_test_names}.\n\
+                    \            The placeholder ${buggy_impl_name} will be replaced\
+                    \ with the name of\n            the buggy impl that the student\
+                    \ test is being run against.\n            If the placeholder ${student_test_name}\
+                    \ is present,\n            it will be replaced with the name of\
+                    \ a single valid student test case,\n            and the command\
+                    \ will be run once for every (buggy implementation, valid test)\
+                    \ pair.\n            If the placeholder ${all_valid_test_names}\
+                    \ is present,\n            it will be replaced with the individually-quoted\
+                    \ names of all valid\n            student tests, and the command\
+                    \ will be run once for each buggy implementation.\n\n        \
+                    \    This latter approach can potentially reduce the runtime (e.g.,\
+                    \ by\n            reducing the number of times an interpreter\
+                    \ is invoked).\n            Note that you may need to specify\
+                    \ a higher time limit with this strategy--for\n            example,\
+                    \ if each individual test takes 1 second to run and running\n\
+                    \            10 tests at once takes 10 seconds, the time limit\
+                    \ will need to be\n            more than 10 seconds, otherwise\
+                    \ buggy impls could be erroneously\n            marked as exposed\
+                    \ due to the tests exceeding a low time limit."
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/Command'
+                points_per_exposed_bug:
+                  description: "The number of points to be awarded per buggy implementation\
+                    \ exposed by\n                     the student test cases. This\
+                    \ field is limited to 4 digits total and a maximum\n         \
+                    \            of 2 decimal places."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                  format: float
+                max_points:
+                  description: An optional ceiling on the number of points to be awarded.
+                  nullable: true
+                  readOnly: false
+                  type: integer
+                deferred:
+                  description: "If true, this mutation test suite can be graded asynchronously.\n\
+                    \                     Deferred suites that have yet to be graded\
+                    \ do not prevent members\n                     of a group from\
+                    \ submitting again."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                sandbox_docker_image:
+                  description: The sandbox docker image to use for running this suite.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/SandboxDockerImage'
+                allow_network_access:
+                  description: "Specifies whether the sandbox should allow commands\
+                    \ run inside of it to\n                     make network calls\
+                    \ outside of the sandbox."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                normal_fdbk_config:
+                  description: Feedback settings for a normal Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                ultimate_submission_fdbk_config:
+                  description: Feedback settings for an ultimate Submission.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                past_limit_submission_fdbk_config:
+                  description: Feedback settings for a Submission that is past the
+                    daily limit.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                staff_viewer_fdbk_config:
+                  description: Feedback settings for a staff member viewing a Submission
+                    from another group.
+                  nullable: false
+                  readOnly: false
+                  allOf:
+                  - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MutationTestSuite'
+          description: ''
+      tags:
+      - mutation_test_suites
+    delete:
+      operationId: deleteMutationTestSuite
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - mutation_test_suites
+  /api/projects/{project_pk}/rerun_submissions_tasks/:
+    get:
+      operationId: listRerunSubmissionsTasks
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RerunSubmissionsTask'
+          description: ''
+      tags:
+      - rerun_submissions_tasks
+    post:
+      operationId: createRerunSubmissionsTask
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                progress:
+                  description: ''
+                  readOnly: true
+                  type: integer
+                is_cancelled:
+                  description: Indicates whether the task has been cancelled by the
+                    user.
+                  nullable: false
+                  readOnly: true
+                  type: boolean
+                error_msg:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                creator:
+                  description: ''
+                  nullable: true
+                  readOnly: true
+                  type: integer
+                  format: id
+                created_at:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                has_error:
+                  description: ''
+                  readOnly: true
+                  type: boolean
+                project:
+                  description: The Project this task belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                rerun_all_submissions:
+                  description: "When True, indicates that all submissions for the\
+                    \ specified\n                     project should be rerun. Otherwise,\
+                    \ only the submissions\n                     whose primary keys\
+                    \ are listed in submission_pks should be rerun."
+                  nullable: false
+                  readOnly: true
+                  type: boolean
+                submission_pks:
+                  description: "When rerun_all_submissions is False, specifies which\
+                    \ submissions\n                     should be rerun."
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: integer
+                rerun_all_ag_test_suites:
+                  description: "When True, indicates that all AGTestSuites belonging\n\
+                    \                     to the specified project should be rerun.\
+                    \ Otherwise,\n                     only the AGTestSuites specified\
+                    \ in ag_test_suite_data should\n                     be rerun."
+                  nullable: false
+                  readOnly: true
+                  type: boolean
+                ag_test_suite_data:
+                  description: "When rerun_all_ag_test_suites is False, specifies\
+                    \ which\n                     AGTestSuites should be rerun and\
+                    \ which AGTestCases within\n                     those suites\
+                    \ should be rerun.\n\n        Data format:\n        {\n      \
+                    \      // Note: JSON format requires that keys are strings. Postgres\n\
+                    \            // doesn't seem to care, but some JSON serializers\
+                    \ might.\n            \"<ag_test_suite_pk>\": [<ag_test_case_pk>,\
+                    \ ...],\n            ...\n        }\n\n        If an ag_test_suite_pk\
+                    \ is mapped to an empty list, then all ag test cases\n       \
+                    \ belonging to that ag test suite will be rerun."
+                  nullable: false
+                  readOnly: true
+                  type: object
+                rerun_all_mutation_test_suites:
+                  description: "When True, indicates that all MutationTestSuites belonging\n\
+                    \                     to the specified project should be rerun.\
+                    \ Otherwise,\n                     only the MutationTestSuites\
+                    \ specified in mutation_test_suite_pks\n                     should\
+                    \ be rerun."
+                  nullable: false
+                  readOnly: true
+                  type: boolean
+                mutation_suite_pks:
+                  description: "When rerun_all_mutation_test_suites is False, specifies\
+                    \ which\n                     mutation test suites should be rerun."
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    description: ''
+                    nullable: false
+                    type: integer
+              required:
+              - creator
+              - project
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RerunSubmissionsTask'
+          description: ''
+      tags:
+      - rerun_submissions_tasks
+  /api/rerun_submissions_tasks/{id}/:
+    get:
+      operationId: getRerunSubmissionsTask
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RerunSubmissionsTask'
+          description: ''
+      tags:
+      - rerun_submissions_tasks
+  /api/groups/{id}/submissions_with_results/:
+    get:
+      operationId: listSubmissionsWithResults
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SubmissionWithResults'
+          description: ''
+      tags:
+      - submissions
+  /api/submissions/{id}/results/:
+    get:
+      operationId: getSubmissionResults
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubmissionResultFeedback'
+          description: ''
+      tags:
+      - submissions
+  /api/projects/{project_pk}/all_ultimate_submission_results/:
+    get:
+      operationId: getAllUltimateSubmissionResults
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/page'
+      - name: groups_per_page
+        in: query
+        description: The number of groups per page. Note that this is NOT the same
+          as the length of the "results" array, as that array has one entry per student.
+          Maximum value is 200
+        schema:
+          type: integer
+          default: 100
+          maximum: 200
+      - name: full_results
+        in: query
+        description: "When \"false\", the submission result data\n               \
+          \         will not contain the \"ag_test_suite_results\"\n             \
+          \           or \"mutation_test_suite_results\" fields.\n               \
+          \         Defaults to \"false\"."
+        schema:
+          type: string
+          enum:
+          - 'true'
+          - 'false'
+          default: 'false'
+      - name: include_pending_extensions
+        in: query
+        description: "When \"false\", the \"ultimate_submission\" field\n        \
+          \                will be set to null for students who have a pending extension.\n\
+          \                        Set to \"true\" to include those submission results.\n\
+          \                        Defaults to \"false\"."
+        schema:
+          type: string
+          enum:
+          - 'true'
+          - 'false'
+          default: 'false'
+      - $ref: '#/components/parameters/includeStaff'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: url
+                  previous:
+                    type: string
+                    format: url
+                  results:
+                    type: array
+                    items:
+                      properties:
+                        username:
+                          type: string
+                          description: The username of the student this entry applies
+                            to. Note that in some (rare) cases involving late day
+                            tokens, users in the same group can have different ultimate
+                            submissions.
+                        group:
+                          $ref: '#/components/schemas/Group'
+                        ultimate_submission:
+                          allOf:
+                          - $ref: '#/components/schemas/Submission'
+                          - type: object
+                            properties:
+                              results:
+                                $ref: '#/components/schemas/SubmissionResultFeedback'
+                          nullable: true
+      tags:
+      - submissions
+  /api/submissions/{id}/ag_test_suite_results/{result_pk}/stdout/:
+    get:
+      operationId: getAGTestSuiteResultStdout
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_suite_results/{result_pk}/stderr/:
+    get:
+      operationId: getAGTestSuiteResultStderr
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_suite_results/{result_pk}/output_size/:
+    get:
+      operationId: getAGTestSuiteResultOutputSize
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  setup_stdout_size:
+                    type: integer
+                    nullable: true
+                  setup_stdout_truncated:
+                    type: boolean
+                    nullable: true
+                  setup_stderr_size:
+                    type: integer
+                    nullable: true
+                  setup_stderr_truncated:
+                    type: boolean
+                    nullable: true
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_cmd_results/{result_pk}/stdout/:
+    get:
+      operationId: getAGTestCommandResultStdout
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_cmd_results/{result_pk}/stderr/:
+    get:
+      operationId: getAGTestCommandResultStderr
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_cmd_results/{result_pk}/stdout_diff/:
+    get:
+      operationId: getAGTestCommandResultStdoutDiff
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                differencesFound:
+                  summary: Expected and actual output differ
+                  value:
+                  - '  spam'
+                  - + egg
+                  - '- sausage'
+                noDifference:
+                  summary: Expected and actual output match
+                  value: []
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_cmd_results/{result_pk}/stderr_diff/:
+    get:
+      operationId: getAGTestCommandResultStderrDiff
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              examples:
+                differencesFound:
+                  summary: Expected and actual output differ
+                  value:
+                  - '  spam'
+                  - + egg
+                  - '- sausage'
+                noDifference:
+                  summary: Expected and actual output match
+                  value: []
+      tags:
+      - submission_output
+  /api/submissions/{id}/ag_test_cmd_results/{result_pk}/output_size/:
+    get:
+      operationId: getAGTestCommandResultOutputSize
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  stdout_size:
+                    type: integer
+                    nullable: true
+                  stdout_truncated:
+                    type: boolean
+                    nullable: true
+                  stderr_size:
+                    type: integer
+                    nullable: true
+                  stderr_truncated:
+                    type: boolean
+                    nullable: true
+                  stdout_diff_size:
+                    type: integer
+                    nullable: true
+                  stderr_diff_size:
+                    type: integer
+                    nullable: true
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/setup_stdout/:
+    get:
+      operationId: getMutationTestSuiteResultSetupStdout
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/setup_stderr/:
+    get:
+      operationId: getMutationTestSuiteResultSetupStderr
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/get_student_test_names_stdout/:
+    get:
+      operationId: getMutationTestSuiteResultTestDiscoveryStdout
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/get_student_test_names_stderr/:
+    get:
+      operationId: getMutationTestSuiteResultTestDiscoveryStderr
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/validity_check_stdout/:
+    get:
+      operationId: getMutationTestSuiteResultValidityCheckStdout
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/validity_check_stderr/:
+    get:
+      operationId: getMutationTestSuiteResultValidityCheckStderr
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/grade_buggy_impls_stdout/:
+    get:
+      operationId: getMutationTestSuiteResultGradeBuggyImplsStdout
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/grade_buggy_impls_stderr/:
+    get:
+      operationId: getMutationTestSuiteResultGradeBuggyImplsStderr
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: ''
+      tags:
+      - submission_output
+  /api/submissions/{id}/mutation_test_suite_results/{result_pk}/output_size/:
+    get:
+      operationId: getMutationTestSuiteResultOutputSize
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/feedbackCategory'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  setup_stdout_size:
+                    type: integer
+                    nullable: true
+                  setup_stderr_size:
+                    type: integer
+                    nullable: true
+                  get_student_test_names_stdout_size:
+                    type: integer
+                    nullable: true
+                  get_student_test_names_stderr_size:
+                    type: integer
+                    nullable: true
+                  validity_check_stdout_size:
+                    type: integer
+                    nullable: true
+                  validity_check_stderr_size:
+                    type: integer
+                    nullable: true
+                  grade_buggy_impls_stdout_size:
+                    type: integer
+                    nullable: true
+                  grade_buggy_impls_stderr_size:
+                    type: integer
+                    nullable: true
+      tags:
+      - submission_output
+  /api/projects/{project_pk}/handgrading_rubric/:
+    get:
+      operationId: getHandgradingRubricForProject
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingRubric'
+          description: ''
+      tags:
+      - handgrading_rubrics
+    post:
+      operationId: createHandgradingRubric
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                project:
+                  description: The Project this HandgradingRubric belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                points_style:
+                  description: "Determines how total_points and total_possible_points\
+                    \ are calculated\n                     for HandgradingResults."
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - start_at_zero_and_add
+                  - start_at_max_and_subtract
+                  type: string
+                max_points:
+                  description: "The denominator of a handgrading score.\n        \
+                    \             When points_style is \"start_at_zero_and_add\",\
+                    \ this value\n                     overrides the sum of positive\
+                    \ Criteria point values as the\n                     total points\
+                    \ possible.\n                     When points_style is \"start_at_max_and_subtract\"\
+                    , this field\n                     is REQUIRED."
+                  nullable: true
+                  readOnly: false
+                  type: number
+                show_grades_and_rubric_to_students:
+                  description: "Whether students can see their handgrading scores,\n\
+                    \                     including information from the rubric."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                show_only_applied_rubric_to_students:
+                  description: "Whether students can see rubric items that\n     \
+                    \                were not applied to their submission."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                handgraders_can_leave_comments:
+                  description: Whether handgraders can add comments to a HandgradingResult.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                handgraders_can_adjust_points:
+                  description: Whether handgraders can edit HandgradingResult.point_adjustment.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                criteria:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Criterion'
+                annotations:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Annotation'
+              required:
+              - project
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingRubric'
+          description: ''
+      tags:
+      - handgrading_rubrics
+  /api/handgrading_rubrics/{id}/:
+    get:
+      operationId: getHandgradingRubric
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingRubric'
+          description: ''
+      tags:
+      - handgrading_rubrics
+    patch:
+      operationId: updateHandgradingRubric
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                project:
+                  description: The Project this HandgradingRubric belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                points_style:
+                  description: "Determines how total_points and total_possible_points\
+                    \ are calculated\n                     for HandgradingResults."
+                  nullable: false
+                  readOnly: false
+                  enum:
+                  - start_at_zero_and_add
+                  - start_at_max_and_subtract
+                  type: string
+                max_points:
+                  description: "The denominator of a handgrading score.\n        \
+                    \             When points_style is \"start_at_zero_and_add\",\
+                    \ this value\n                     overrides the sum of positive\
+                    \ Criteria point values as the\n                     total points\
+                    \ possible.\n                     When points_style is \"start_at_max_and_subtract\"\
+                    , this field\n                     is REQUIRED."
+                  nullable: true
+                  readOnly: false
+                  type: number
+                show_grades_and_rubric_to_students:
+                  description: "Whether students can see their handgrading scores,\n\
+                    \                     including information from the rubric."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                show_only_applied_rubric_to_students:
+                  description: "Whether students can see rubric items that\n     \
+                    \                were not applied to their submission."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                handgraders_can_leave_comments:
+                  description: Whether handgraders can add comments to a HandgradingResult.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                handgraders_can_adjust_points:
+                  description: Whether handgraders can edit HandgradingResult.point_adjustment.
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                criteria:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Criterion'
+                annotations:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Annotation'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingRubric'
+          description: ''
+      tags:
+      - handgrading_rubrics
+    delete:
+      operationId: deleteHandgradingRubric
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - handgrading_rubrics
+  /api/handgrading_rubrics/{handgrading_rubric_pk}/annotations/:
+    get:
+      operationId: listAnnotations
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Annotation'
+          description: ''
+      tags:
+      - annotations
+    post:
+      operationId: createAnnotation
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                handgrading_rubric:
+                  description: The HandgradingRubric this Annotation belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                short_description:
+                  description: A short description of this Annotation.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                long_description:
+                  description: "A long description of this Criterion. Note that there\
+                    \ is no\n                     enforced length difference between\
+                    \ short_ and long_description.\n                     The separation\
+                    \ is purely to be used by clients."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                deduction:
+                  description: "The amount of points to deduct from a handgrading\
+                    \ score when\n                     applied. Must be non-positive."
+                  nullable: false
+                  readOnly: false
+                  type: number
+                max_deduction:
+                  description: "The maximum amount of points that can be cumulatively\n\
+                    \                     deducted from a handgrading score by applications\
+                    \ of\n                     this annotation. Must be None or non-positive."
+                  nullable: true
+                  readOnly: false
+                  type: number
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+              required:
+              - handgrading_rubric
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Annotation'
+          description: ''
+      tags:
+      - annotations
+  /api/annotations/{id}/:
+    get:
+      operationId: getAnnotation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Annotation'
+          description: ''
+      tags:
+      - annotations
+    patch:
+      operationId: updateAnnotation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                handgrading_rubric:
+                  description: The HandgradingRubric this Annotation belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                short_description:
+                  description: A short description of this Annotation.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                long_description:
+                  description: "A long description of this Criterion. Note that there\
+                    \ is no\n                     enforced length difference between\
+                    \ short_ and long_description.\n                     The separation\
+                    \ is purely to be used by clients."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                deduction:
+                  description: "The amount of points to deduct from a handgrading\
+                    \ score when\n                     applied. Must be non-positive."
+                  nullable: false
+                  readOnly: false
+                  type: number
+                max_deduction:
+                  description: "The maximum amount of points that can be cumulatively\n\
+                    \                     deducted from a handgrading score by applications\
+                    \ of\n                     this annotation. Must be None or non-positive."
+                  nullable: true
+                  readOnly: false
+                  type: number
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Annotation'
+          description: ''
+      tags:
+      - annotations
+    delete:
+      operationId: deleteAnnotation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - annotations
+  /api/handgrading_rubrics/{handgrading_rubric_pk}/annotations/order/:
+    get:
+      operationId: getAnnotationOrder
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - annotations
+    put:
+      operationId: setAnnotationOrder
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: id
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - annotations
+  /api/handgrading_rubrics/{handgrading_rubric_pk}/criteria/:
+    get:
+      operationId: listCriterions
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Criterion'
+          description: ''
+      tags:
+      - criteria
+    post:
+      operationId: createCriterion
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                handgrading_rubric:
+                  description: The rubric this Criterion belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                short_description:
+                  description: A short description of this Criterion.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                long_description:
+                  description: "A long description of this Criterion. Note that there\
+                    \ is no\n                     enforced length difference between\
+                    \ short_ and long_description.\n                     The separation\
+                    \ is purely to be used by clients."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                points:
+                  description: "The amount of points to add or subtract from a handgrading\
+                    \ score\n                     when selected."
+                  nullable: false
+                  readOnly: false
+                  type: number
+              required:
+              - handgrading_rubric
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Criterion'
+          description: ''
+      tags:
+      - criteria
+  /api/criteria/{id}/:
+    get:
+      operationId: getCriterion
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Criterion'
+          description: ''
+      tags:
+      - criteria
+    patch:
+      operationId: updateCriterion
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                handgrading_rubric:
+                  description: The rubric this Criterion belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                short_description:
+                  description: A short description of this Criterion.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                long_description:
+                  description: "A long description of this Criterion. Note that there\
+                    \ is no\n                     enforced length difference between\
+                    \ short_ and long_description.\n                     The separation\
+                    \ is purely to be used by clients."
+                  nullable: false
+                  readOnly: false
+                  type: string
+                points:
+                  description: "The amount of points to add or subtract from a handgrading\
+                    \ score\n                     when selected."
+                  nullable: false
+                  readOnly: false
+                  type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Criterion'
+          description: ''
+      tags:
+      - criteria
+    delete:
+      operationId: deleteCriterion
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - criteria
+  /api/handgrading_rubrics/{handgrading_rubric_pk}/criteria/order/:
+    get:
+      operationId: getCriterionOrder
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - criteria
+    put:
+      operationId: setCriterionOrder
+      description: ''
+      parameters:
+      - name: handgrading_rubric_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: integer
+                format: id
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: id
+      tags:
+      - criteria
+  /api/groups/{group_pk}/handgrading_result/:
+    get:
+      operationId: getHandgradingResult
+      description: ''
+      parameters:
+      - name: group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingResult'
+          description: ''
+      tags:
+      - handgrading_results
+    post:
+      operationId: getOrCreateHandgradingResult
+      description: 'Creates a new HandgradingResult for the specified Group, or returns
+
+        an already existing one.'
+      parameters:
+      - name: group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '200':
+          description: A HandgradingResult already exists for the group. That HandgradingResult
+            is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingResult'
+        '201':
+          description: A new HandgradingResult was created for the group.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingResult'
+      tags:
+      - handgrading_results
+    patch:
+      operationId: updateHandgradingResult
+      description: ''
+      parameters:
+      - name: group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                submission:
+                  description: The specific submission that is being handgraded.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                handgrading_rubric:
+                  description: The HandgradingRubric that this HandgradingResult is
+                    based on.
+                  nullable: false
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/HandgradingRubric'
+                group:
+                  description: The SubmissionGroup that this HandgradingResult is
+                    for.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+                applied_annotations:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/AppliedAnnotation'
+                comments:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Comment'
+                criterion_results:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/CriterionResult'
+                finished_grading:
+                  description: "Handgraders should set this field to True when they\
+                    \ are finished\n                     grading this group's submission."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                points_adjustment:
+                  description: "An arbitrary adjustment to this result's total points.\n\
+                    \                     Note that this does not affect total points\
+                    \ possible."
+                  nullable: false
+                  readOnly: false
+                  type: number
+                submitted_filenames:
+                  description: "Returns a list of strings containing the filenames\
+                    \ of the Submission this result\n        belongs to.\n\n     \
+                    \   If any of the filenames have the .zip extension, will attempt\
+                    \ to include the paths\n        of files inside the zip archive.\
+                    \ These entries will be of the form:\n            {zip_filename}/zip/member/path\n\
+                    \n        For example, if a file \"submission.zip\" was submitted\
+                    \ that contains a file\n        called \"tests.py\", the entry\
+                    \ for tests.py would be:\n            submission.zip/tests.py"
+                  readOnly: true
+                  type: array
+                  items:
+                    type: string
+                total_points:
+                  description: "The total number of points awarded. Note that it is\
+                    \ possible\n        for this value to be greater than total_points."
+                  readOnly: true
+                  type: number
+                total_points_possible:
+                  description: "The denominator of the handgrading score based on\
+                    \ the\n        handgrading rubric's points style and max points."
+                  readOnly: true
+                  type: number
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingResult'
+          description: ''
+      tags:
+      - handgrading_results
+    delete:
+      operationId: deleteHandgradingResult
+      description: ''
+      parameters:
+      - name: group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - handgrading_results
+  /api/groups/{group_pk}/handgrading_result/file/:
+    get:
+      operationId: getHandgradingResultFile
+      description: ''
+      parameters:
+      - name: group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: filename
+        in: query
+        description: The name of a submitted file to return.
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          description: The file content.
+      tags:
+      - handgrading_results
+  /api/groups/{group_pk}/handgrading_result/has_correct_submission/:
+    get:
+      operationId: handgradingResultHasCorrectSubmission
+      description: 'Returns true if the submission linked to the group''s handgrading
+        result
+
+        is the same as that group''s current final graded submission.'
+      parameters:
+      - name: group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: boolean
+          description: ''
+      tags:
+      - handgrading_results
+  /api/handgrading_results/{handgrading_result_pk}/applied_annotations/:
+    get:
+      operationId: listAppliedAnnotations
+      description: ''
+      parameters:
+      - name: handgrading_result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AppliedAnnotation'
+          description: ''
+      tags:
+      - applied_annotations
+    post:
+      operationId: createAppliedAnnotation
+      description: ''
+      parameters:
+      - name: handgrading_result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                location:
+                  description: The source code location where the Annotation was applied.
+                  nullable: false
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/Location'
+                annotation:
+                  description: The Annotation that was applied to the source code.
+                  nullable: false
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/Annotation'
+                handgrading_result:
+                  description: The HandgradingResult the applied annotation belongs
+                    to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+              required:
+              - location
+              - annotation
+              - handgrading_result
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedAnnotation'
+          description: ''
+      tags:
+      - applied_annotations
+  /api/applied_annotations/{id}/:
+    get:
+      operationId: getAppliedAnnotation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AppliedAnnotation'
+          description: ''
+      tags:
+      - applied_annotations
+    delete:
+      operationId: deleteAppliedAnnotation
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - applied_annotations
+  /api/handgrading_results/{handgrading_result_pk}/comments/:
+    get:
+      operationId: listComments
+      description: ''
+      parameters:
+      - name: handgrading_result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Comment'
+          description: ''
+      tags:
+      - comments
+    post:
+      operationId: createComment
+      description: ''
+      parameters:
+      - name: handgrading_result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                location:
+                  description: "When not None, specifies the source code location\
+                    \ this comment\n                     applies to."
+                  nullable: true
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/Location'
+                text:
+                  description: Text to be shown to students.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                handgrading_result:
+                  description: The HandgradingResult that this Comment belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+              required:
+              - text
+              - handgrading_result
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+          description: ''
+      tags:
+      - comments
+  /api/comments/{id}/:
+    get:
+      operationId: getComment
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+          description: ''
+      tags:
+      - comments
+    patch:
+      operationId: updateComment
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                location:
+                  description: "When not None, specifies the source code location\
+                    \ this comment\n                     applies to."
+                  nullable: true
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/Location'
+                text:
+                  description: Text to be shown to students.
+                  nullable: false
+                  readOnly: false
+                  type: string
+                handgrading_result:
+                  description: The HandgradingResult that this Comment belongs to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Comment'
+          description: ''
+      tags:
+      - comments
+    delete:
+      operationId: deleteComment
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - comments
+  /api/handgrading_results/{handgrading_result_pk}/criterion_results/:
+    get:
+      operationId: listCriterionResults
+      description: ''
+      parameters:
+      - name: handgrading_result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CriterionResult'
+          description: ''
+      tags:
+      - criterion_results
+    post:
+      operationId: createCriterionResult
+      description: ''
+      parameters:
+      - name: handgrading_result_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                selected:
+                  description: "When True, indicates that the criterion's point allotment\
+                    \ should be\n                     added to (or subtracted from\
+                    \ if negative) the total handgrading points."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                criterion:
+                  description: The Criterion that the CriterionResult is tied to.
+                  nullable: false
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/Criterion'
+                handgrading_result:
+                  description: The HandgradingResult this CriterionResult belongs
+                    to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+              required:
+              - selected
+              - criterion
+              - handgrading_result
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CriterionResult'
+          description: ''
+      tags:
+      - criterion_results
+  /api/criterion_results/{id}/:
+    get:
+      operationId: getCriterionResult
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CriterionResult'
+          description: ''
+      tags:
+      - criterion_results
+    patch:
+      operationId: updateCriterionResult
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                pk:
+                  type: integer
+                  format: id
+                  readOnly: true
+                last_modified:
+                  description: ''
+                  nullable: false
+                  readOnly: true
+                  type: string
+                  format: date-time
+                selected:
+                  description: "When True, indicates that the criterion's point allotment\
+                    \ should be\n                     added to (or subtracted from\
+                    \ if negative) the total handgrading points."
+                  nullable: false
+                  readOnly: false
+                  type: boolean
+                criterion:
+                  description: The Criterion that the CriterionResult is tied to.
+                  nullable: false
+                  readOnly: true
+                  allOf:
+                  - $ref: '#/components/schemas/Criterion'
+                handgrading_result:
+                  description: The HandgradingResult this CriterionResult belongs
+                    to.
+                  nullable: false
+                  readOnly: true
+                  type: integer
+                  format: id
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CriterionResult'
+          description: ''
+      tags:
+      - criterion_results
+    delete:
+      operationId: deleteCriterionResult
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - criterion_results
+  /api/projects/{id}/handgrading_results/:
+    get:
+      operationId: listHandgradingResults
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - $ref: '#/components/parameters/page'
+      - name: page_size
+        in: query
+        description: The page size. Maximum value is 1000
+        schema:
+          type: integer
+          default: 500
+          maximum: 1000
+      - $ref: '#/components/parameters/includeStaff'
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: integer
+                  next:
+                    type: string
+                    format: url
+                  previous:
+                    type: string
+                    format: url
+                  results:
+                    type: array
+                    items:
+                      allOf:
+                      - $ref: '#/components/schemas/Group'
+                      - type: object
+                        properties:
+                          handgrading_result:
+                            description: When this value is null, indicates that handgrading
+                              has not started for this group.
+                            type: object
+                            nullable: true
+                            properties:
+                              finished_grading:
+                                type: boolean
+                              total_points:
+                                type: number
+                                format: double
+                              total_points_possible:
+                                type: number
+                                format: double
+      tags:
+      - projects
+      - handgrading_results
+  /api/courses/{id}/copy/:
+    post:
+      operationId: copyCourse
+      description: 'Makes a copy of the given course and all its projects.
+
+        The projects and all of their  instructor file,
+
+        expected student file, test case, and handgrading data.
+
+        Note that groups, submissions, and results (test case, handgrading,
+
+        etc.) are NOT copied.
+
+        The admin list is copied to the new project, but other permissions
+
+        (staff, students, etc.) are not.'
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - new_name
+              - new_semester
+              - new_year
+              properties:
+                new_name:
+                  type: string
+                new_semester:
+                  $ref: '#/components/schemas/Semester'
+                new_year:
+                  type: integer
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Course'
+          description: ''
+      tags:
+      - courses
+  /api/projects/{project_pk}/copy_to_course/{target_course_pk}/:
+    post:
+      operationId: copyProject
+      description: 'Makes a copy of the specified project and
+
+        all of its instructor file, expected student file, test case,
+
+        and handgrading data.
+
+        Note that groups, submissions, and results (test case, handgrading,
+
+        etc.) are NOT copied.'
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: target_course_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                new_project_name:
+                  type: string
+                  description: "The name for the new project.\n                  \
+                    \                      Only required if the target course is the\
+                    \ same as the\n                                        one the\
+                    \ project belongs to.\n                                    "
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Project'
+          description: ''
+      tags:
+      - projects
+  /api/projects/{project_pk}/import_handgrading_rubric_from/{import_from_project_pk}/:
+    post:
+      operationId: importHandgradingRubric
+      description: ''
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: import_from_project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HandgradingRubric'
+          description: ''
+      tags:
+      - projects
+      - handgrading_rubrics
+  /api/group_invitations/{id}/accept/:
+    post:
+      operationId: acceptGroupInvitation
+      description: 'Accept this group invitation. If all recipients have accepted,
+
+        create a group, delete the invitation, and return the group.'
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '200':
+          description: You have accepted the invitation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GroupInvitation'
+        '201':
+          description: All invited users have accepted the invitation.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+      tags:
+      - group_invitations
+  /api/projects/{project_pk}/groups/solo_group/:
+    post:
+      operationId: createSoloGroup
+      description: Creates a group containing only the user making the request.
+      parameters:
+      - name: project_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - groups
+  /api/groups/{id}/merge_with/{other_group_pk}/:
+    post:
+      operationId: mergeGroups
+      description: 'Merge two groups together, preserving their submissions, and
+
+        return the newly created group.'
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      - name: other_group_pk
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Group'
+          description: ''
+      tags:
+      - groups
+  /api/submissions/{id}/remove_from_queue/:
+    post:
+      operationId: removeSubmissionFromQueue
+      description: Remove this submission from the grading queue.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
+          description: ''
+      tags:
+      - submissions
+  /api/image_build_tasks/{id}/cancel/:
+    post:
+      operationId: cancelBuildSandboxDockerImageTask
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: ''
+      tags:
+      - sandbox_docker_images
+  /api/rerun_submissions_tasks/{id}/cancel/:
+    post:
+      operationId: cancelRerunSubmissionsTask
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema: {}
+          application/x-www-form-urlencoded:
+            schema: {}
+          multipart/form-data:
+            schema: {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RerunSubmissionsTask'
+          description: ''
+      tags:
+      - rerun_submissions_tasks
+  /api/instructor_files/{id}/name/:
+    put:
+      operationId: renameInstructorFile
+      description: ''
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InstructorFile'
+          description: ''
+      tags:
+      - instructor_files
+  /api/sandbox_docker_images/{id}/rebuild/:
+    put:
+      operationId: rebuildSandboxDockerImage
+      description: Rebuild the specified image using the files uploaded.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                files:
+                  description: The form-encoded files. One file must be named "Dockerfile"
+                  type: array
+                  items:
+                    type: string
+                    format: binary
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BuildSandboxDockerImageTask'
+          description: The build task has been started.
+      tags:
+      - sandbox_docker_images
+  /api/users/current/revoke_api_token/:
+    delete:
+      operationId: revokeCurrentUserAPIToken
+      description: Revoke the current user's API token.
+      parameters: []
+      responses:
+        '204':
+          description: ''
+      tags:
+      - users
+  /api/projects/{id}/results_cache/:
+    delete:
+      operationId: clearSubmissionResultsCache
+      description: DEPRECATED. Clears cached "normal" feedback submission results.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: ''
+        schema:
+          type: string
+      responses:
+        '204':
+          description: ''
+      tags:
+      - projects
+      deprecated: true
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        username:
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+          nullable: false
+          type: string
+          format: email
+        first_name:
+          description: ''
+          nullable: false
+          type: string
+        last_name:
+          description: ''
+          nullable: false
+          type: string
+        is_superuser:
+          description: Designates that this user has all permissions without explicitly
+            assigning them.
+          nullable: false
+          type: boolean
+    Course:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        name:
+          description: The name of this course. Must be unique, non-empty and non-null.
+          nullable: false
+          type: string
+        semester:
+          description: ''
+          nullable: true
+          enum:
+          - Fall
+          - Winter
+          - Spring
+          - Summer
+          type: string
+        year:
+          description: ''
+          nullable: true
+          type: integer
+        subtitle:
+          description: An optional descriptive name for the course.
+          nullable: false
+          type: string
+        num_late_days:
+          description: The number of late days to give to users submitting to this
+            course's projects.
+          nullable: false
+          type: integer
+        allowed_guest_domain:
+          description: "When non-empty, indicates that guest users' usernames\n  \
+            \                   must end with this string for them to be allowed access\n\
+            \                     to projects that allow guests.\n               \
+            \      When empty, indicates that all guests can access projects\n   \
+            \                  in this course where guests are allowed access."
+          nullable: false
+          type: string
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    Semester:
+      type: string
+      enum:
+      - Fall
+      - Winter
+      - Spring
+      - Summer
+    Project:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        name:
+          description: "The name used to identify this project.\n            Must\
+            \ be non-empty and non-null.\n            Must be unique among Projects\
+            \ associated with\n            a given course.\n            This field\
+            \ is REQUIRED."
+          nullable: false
+          type: string
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        course:
+          description: "The Course this project belongs to.\n            This field\
+            \ is REQUIRED."
+          nullable: false
+          type: integer
+          format: id
+        visible_to_students:
+          description: "Whether information about this Project can\n            be\
+            \ viewed by students."
+          nullable: false
+          type: boolean
+        closing_time:
+          description: "The date and time that this project should stop\n        \
+            \    accepting submissions.\n            A value of None indicates that\
+            \ this project should\n            stay open.\n            In the API,\
+            \ this field is hidden from non-admins."
+          nullable: true
+          type: string
+          format: date-time
+        soft_closing_time:
+          description: "The date and time that should be displayed as the\n      \
+            \      due date for this project. Unlike closing_time,\n            soft_closing_time\
+            \ does not affect whether submissions are\n            actually accepted.\n\
+            \            If not None and closing_time is not None, this value must\
+            \ be\n            less than (before) closing_time."
+          nullable: true
+          type: string
+          format: date-time
+        disallow_student_submissions:
+          description: "A hard override that indicates that students should\n    \
+            \        be prevented from submitting even if visible_to_students is\n\
+            \            True and it is before closing_time."
+          nullable: false
+          type: boolean
+        disallow_group_registration:
+          description: "A hard override that indicates that students should\n    \
+            \        not be able to send, accept, or reject group\n            invitations."
+          nullable: false
+          type: boolean
+        guests_can_submit:
+          description: "By default, only admins, staff, and students\n           \
+            \ for a given Course can view and submit to its Projects.\n          \
+            \  When True, submissions will be accepted from guests\n            with\
+            \ the following caveats:\n                - Guests must be given a direct\
+            \ link to the project.\n                - When group work is allowed,\
+            \ guests can\n                only be in groups with other guests."
+          nullable: false
+          type: boolean
+        min_group_size:
+          description: "The minimum number of students that can work in a\n      \
+            \      group on this project.\n            Must be >= 1.\n           \
+            \ Must be <= max_group_size."
+          nullable: false
+          type: integer
+        max_group_size:
+          description: "The maximum number of students that can work in a\n      \
+            \      group on this project.\n            Must be >= 1.\n           \
+            \ Must be >= min_group_size."
+          nullable: false
+          type: integer
+        submission_limit_per_day:
+          description: "The number of submissions each group is allowed per\n    \
+            \        day before either reducing feedback or preventing further\n \
+            \           submissions. A value of None indicates no limit."
+          nullable: true
+          type: integer
+        allow_submissions_past_limit:
+          description: "Whether to allow additional submissions after a\n        \
+            \    group has submitted submission_limit_per_day times."
+          nullable: false
+          type: boolean
+        groups_combine_daily_submissions:
+          description: "If True, group members can \"pool\" their daily submissions.\n\
+            \            For example, if submission_limit_per_day is 3,\n        \
+            \    a group with 2 members would get 6 submissions per day."
+          nullable: false
+          type: boolean
+        submission_limit_reset_time:
+          description: "The time that marks the beginning and end of the 24\n    \
+            \        hour period during which submissions should be counted\n    \
+            \        towards the daily limit. Defaults to 00:00:00."
+          nullable: false
+          type: string
+          format: time
+        submission_limit_reset_timezone:
+          description: "A string representing the timezone to use when computing\n\
+            \            how many submissions a group has made in a 24 hour period."
+          nullable: false
+          enum:
+          - Africa/Abidjan
+          - Africa/Accra
+          - Africa/Addis_Ababa
+          - Africa/Algiers
+          - Africa/Asmara
+          - Africa/Asmera
+          - Africa/Bamako
+          - Africa/Bangui
+          - Africa/Banjul
+          - Africa/Bissau
+          - Africa/Blantyre
+          - Africa/Brazzaville
+          - Africa/Bujumbura
+          - Africa/Cairo
+          - Africa/Casablanca
+          - Africa/Ceuta
+          - Africa/Conakry
+          - Africa/Dakar
+          - Africa/Dar_es_Salaam
+          - Africa/Djibouti
+          - Africa/Douala
+          - Africa/El_Aaiun
+          - Africa/Freetown
+          - Africa/Gaborone
+          - Africa/Harare
+          - Africa/Johannesburg
+          - Africa/Juba
+          - Africa/Kampala
+          - Africa/Khartoum
+          - Africa/Kigali
+          - Africa/Kinshasa
+          - Africa/Lagos
+          - Africa/Libreville
+          - Africa/Lome
+          - Africa/Luanda
+          - Africa/Lubumbashi
+          - Africa/Lusaka
+          - Africa/Malabo
+          - Africa/Maputo
+          - Africa/Maseru
+          - Africa/Mbabane
+          - Africa/Mogadishu
+          - Africa/Monrovia
+          - Africa/Nairobi
+          - Africa/Ndjamena
+          - Africa/Niamey
+          - Africa/Nouakchott
+          - Africa/Ouagadougou
+          - Africa/Porto-Novo
+          - Africa/Sao_Tome
+          - Africa/Timbuktu
+          - Africa/Tripoli
+          - Africa/Tunis
+          - Africa/Windhoek
+          - America/Adak
+          - America/Anchorage
+          - America/Anguilla
+          - America/Antigua
+          - America/Araguaina
+          - America/Argentina/Buenos_Aires
+          - America/Argentina/Catamarca
+          - America/Argentina/ComodRivadavia
+          - America/Argentina/Cordoba
+          - America/Argentina/Jujuy
+          - America/Argentina/La_Rioja
+          - America/Argentina/Mendoza
+          - America/Argentina/Rio_Gallegos
+          - America/Argentina/Salta
+          - America/Argentina/San_Juan
+          - America/Argentina/San_Luis
+          - America/Argentina/Tucuman
+          - America/Argentina/Ushuaia
+          - America/Aruba
+          - America/Asuncion
+          - America/Atikokan
+          - America/Atka
+          - America/Bahia
+          - America/Bahia_Banderas
+          - America/Barbados
+          - America/Belem
+          - America/Belize
+          - America/Blanc-Sablon
+          - America/Boa_Vista
+          - America/Bogota
+          - America/Boise
+          - America/Buenos_Aires
+          - America/Cambridge_Bay
+          - America/Campo_Grande
+          - America/Cancun
+          - America/Caracas
+          - America/Catamarca
+          - America/Cayenne
+          - America/Cayman
+          - America/Chicago
+          - America/Chihuahua
+          - America/Ciudad_Juarez
+          - America/Coral_Harbour
+          - America/Cordoba
+          - America/Costa_Rica
+          - America/Creston
+          - America/Cuiaba
+          - America/Curacao
+          - America/Danmarkshavn
+          - America/Dawson
+          - America/Dawson_Creek
+          - America/Denver
+          - America/Detroit
+          - America/Dominica
+          - America/Edmonton
+          - America/Eirunepe
+          - America/El_Salvador
+          - America/Ensenada
+          - America/Fort_Nelson
+          - America/Fort_Wayne
+          - America/Fortaleza
+          - America/Glace_Bay
+          - America/Godthab
+          - America/Goose_Bay
+          - America/Grand_Turk
+          - America/Grenada
+          - America/Guadeloupe
+          - America/Guatemala
+          - America/Guayaquil
+          - America/Guyana
+          - America/Halifax
+          - America/Havana
+          - America/Hermosillo
+          - America/Indiana/Indianapolis
+          - America/Indiana/Knox
+          - America/Indiana/Marengo
+          - America/Indiana/Petersburg
+          - America/Indiana/Tell_City
+          - America/Indiana/Vevay
+          - America/Indiana/Vincennes
+          - America/Indiana/Winamac
+          - America/Indianapolis
+          - America/Inuvik
+          - America/Iqaluit
+          - America/Jamaica
+          - America/Jujuy
+          - America/Juneau
+          - America/Kentucky/Louisville
+          - America/Kentucky/Monticello
+          - America/Knox_IN
+          - America/Kralendijk
+          - America/La_Paz
+          - America/Lima
+          - America/Los_Angeles
+          - America/Louisville
+          - America/Lower_Princes
+          - America/Maceio
+          - America/Managua
+          - America/Manaus
+          - America/Marigot
+          - America/Martinique
+          - America/Matamoros
+          - America/Mazatlan
+          - America/Mendoza
+          - America/Menominee
+          - America/Merida
+          - America/Metlakatla
+          - America/Mexico_City
+          - America/Miquelon
+          - America/Moncton
+          - America/Monterrey
+          - America/Montevideo
+          - America/Montreal
+          - America/Montserrat
+          - America/Nassau
+          - America/New_York
+          - America/Nipigon
+          - America/Nome
+          - America/Noronha
+          - America/North_Dakota/Beulah
+          - America/North_Dakota/Center
+          - America/North_Dakota/New_Salem
+          - America/Nuuk
+          - America/Ojinaga
+          - America/Panama
+          - America/Pangnirtung
+          - America/Paramaribo
+          - America/Phoenix
+          - America/Port-au-Prince
+          - America/Port_of_Spain
+          - America/Porto_Acre
+          - America/Porto_Velho
+          - America/Puerto_Rico
+          - America/Punta_Arenas
+          - America/Rainy_River
+          - America/Rankin_Inlet
+          - America/Recife
+          - America/Regina
+          - America/Resolute
+          - America/Rio_Branco
+          - America/Rosario
+          - America/Santa_Isabel
+          - America/Santarem
+          - America/Santiago
+          - America/Santo_Domingo
+          - America/Sao_Paulo
+          - America/Scoresbysund
+          - America/Shiprock
+          - America/Sitka
+          - America/St_Barthelemy
+          - America/St_Johns
+          - America/St_Kitts
+          - America/St_Lucia
+          - America/St_Thomas
+          - America/St_Vincent
+          - America/Swift_Current
+          - America/Tegucigalpa
+          - America/Thule
+          - America/Thunder_Bay
+          - America/Tijuana
+          - America/Toronto
+          - America/Tortola
+          - America/Vancouver
+          - America/Virgin
+          - America/Whitehorse
+          - America/Winnipeg
+          - America/Yakutat
+          - America/Yellowknife
+          - Antarctica/Casey
+          - Antarctica/Davis
+          - Antarctica/DumontDUrville
+          - Antarctica/Macquarie
+          - Antarctica/Mawson
+          - Antarctica/McMurdo
+          - Antarctica/Palmer
+          - Antarctica/Rothera
+          - Antarctica/South_Pole
+          - Antarctica/Syowa
+          - Antarctica/Troll
+          - Antarctica/Vostok
+          - Arctic/Longyearbyen
+          - Asia/Aden
+          - Asia/Almaty
+          - Asia/Amman
+          - Asia/Anadyr
+          - Asia/Aqtau
+          - Asia/Aqtobe
+          - Asia/Ashgabat
+          - Asia/Ashkhabad
+          - Asia/Atyrau
+          - Asia/Baghdad
+          - Asia/Bahrain
+          - Asia/Baku
+          - Asia/Bangkok
+          - Asia/Barnaul
+          - Asia/Beirut
+          - Asia/Bishkek
+          - Asia/Brunei
+          - Asia/Calcutta
+          - Asia/Chita
+          - Asia/Choibalsan
+          - Asia/Chongqing
+          - Asia/Chungking
+          - Asia/Colombo
+          - Asia/Dacca
+          - Asia/Damascus
+          - Asia/Dhaka
+          - Asia/Dili
+          - Asia/Dubai
+          - Asia/Dushanbe
+          - Asia/Famagusta
+          - Asia/Gaza
+          - Asia/Harbin
+          - Asia/Hebron
+          - Asia/Ho_Chi_Minh
+          - Asia/Hong_Kong
+          - Asia/Hovd
+          - Asia/Irkutsk
+          - Asia/Istanbul
+          - Asia/Jakarta
+          - Asia/Jayapura
+          - Asia/Jerusalem
+          - Asia/Kabul
+          - Asia/Kamchatka
+          - Asia/Karachi
+          - Asia/Kashgar
+          - Asia/Kathmandu
+          - Asia/Katmandu
+          - Asia/Khandyga
+          - Asia/Kolkata
+          - Asia/Krasnoyarsk
+          - Asia/Kuala_Lumpur
+          - Asia/Kuching
+          - Asia/Kuwait
+          - Asia/Macao
+          - Asia/Macau
+          - Asia/Magadan
+          - Asia/Makassar
+          - Asia/Manila
+          - Asia/Muscat
+          - Asia/Nicosia
+          - Asia/Novokuznetsk
+          - Asia/Novosibirsk
+          - Asia/Omsk
+          - Asia/Oral
+          - Asia/Phnom_Penh
+          - Asia/Pontianak
+          - Asia/Pyongyang
+          - Asia/Qatar
+          - Asia/Qostanay
+          - Asia/Qyzylorda
+          - Asia/Rangoon
+          - Asia/Riyadh
+          - Asia/Saigon
+          - Asia/Sakhalin
+          - Asia/Samarkand
+          - Asia/Seoul
+          - Asia/Shanghai
+          - Asia/Singapore
+          - Asia/Srednekolymsk
+          - Asia/Taipei
+          - Asia/Tashkent
+          - Asia/Tbilisi
+          - Asia/Tehran
+          - Asia/Tel_Aviv
+          - Asia/Thimbu
+          - Asia/Thimphu
+          - Asia/Tokyo
+          - Asia/Tomsk
+          - Asia/Ujung_Pandang
+          - Asia/Ulaanbaatar
+          - Asia/Ulan_Bator
+          - Asia/Urumqi
+          - Asia/Ust-Nera
+          - Asia/Vientiane
+          - Asia/Vladivostok
+          - Asia/Yakutsk
+          - Asia/Yangon
+          - Asia/Yekaterinburg
+          - Asia/Yerevan
+          - Atlantic/Azores
+          - Atlantic/Bermuda
+          - Atlantic/Canary
+          - Atlantic/Cape_Verde
+          - Atlantic/Faeroe
+          - Atlantic/Faroe
+          - Atlantic/Jan_Mayen
+          - Atlantic/Madeira
+          - Atlantic/Reykjavik
+          - Atlantic/South_Georgia
+          - Atlantic/St_Helena
+          - Atlantic/Stanley
+          - Australia/ACT
+          - Australia/Adelaide
+          - Australia/Brisbane
+          - Australia/Broken_Hill
+          - Australia/Canberra
+          - Australia/Currie
+          - Australia/Darwin
+          - Australia/Eucla
+          - Australia/Hobart
+          - Australia/LHI
+          - Australia/Lindeman
+          - Australia/Lord_Howe
+          - Australia/Melbourne
+          - Australia/NSW
+          - Australia/North
+          - Australia/Perth
+          - Australia/Queensland
+          - Australia/South
+          - Australia/Sydney
+          - Australia/Tasmania
+          - Australia/Victoria
+          - Australia/West
+          - Australia/Yancowinna
+          - Brazil/Acre
+          - Brazil/DeNoronha
+          - Brazil/East
+          - Brazil/West
+          - CET
+          - CST6CDT
+          - Canada/Atlantic
+          - Canada/Central
+          - Canada/Eastern
+          - Canada/Mountain
+          - Canada/Newfoundland
+          - Canada/Pacific
+          - Canada/Saskatchewan
+          - Canada/Yukon
+          - Chile/Continental
+          - Chile/EasterIsland
+          - Cuba
+          - EET
+          - EST
+          - EST5EDT
+          - Egypt
+          - Eire
+          - Etc/GMT
+          - Etc/GMT+0
+          - Etc/GMT+1
+          - Etc/GMT+10
+          - Etc/GMT+11
+          - Etc/GMT+12
+          - Etc/GMT+2
+          - Etc/GMT+3
+          - Etc/GMT+4
+          - Etc/GMT+5
+          - Etc/GMT+6
+          - Etc/GMT+7
+          - Etc/GMT+8
+          - Etc/GMT+9
+          - Etc/GMT-0
+          - Etc/GMT-1
+          - Etc/GMT-10
+          - Etc/GMT-11
+          - Etc/GMT-12
+          - Etc/GMT-13
+          - Etc/GMT-14
+          - Etc/GMT-2
+          - Etc/GMT-3
+          - Etc/GMT-4
+          - Etc/GMT-5
+          - Etc/GMT-6
+          - Etc/GMT-7
+          - Etc/GMT-8
+          - Etc/GMT-9
+          - Etc/GMT0
+          - Etc/Greenwich
+          - Etc/UCT
+          - Etc/UTC
+          - Etc/Universal
+          - Etc/Zulu
+          - Europe/Amsterdam
+          - Europe/Andorra
+          - Europe/Astrakhan
+          - Europe/Athens
+          - Europe/Belfast
+          - Europe/Belgrade
+          - Europe/Berlin
+          - Europe/Bratislava
+          - Europe/Brussels
+          - Europe/Bucharest
+          - Europe/Budapest
+          - Europe/Busingen
+          - Europe/Chisinau
+          - Europe/Copenhagen
+          - Europe/Dublin
+          - Europe/Gibraltar
+          - Europe/Guernsey
+          - Europe/Helsinki
+          - Europe/Isle_of_Man
+          - Europe/Istanbul
+          - Europe/Jersey
+          - Europe/Kaliningrad
+          - Europe/Kiev
+          - Europe/Kirov
+          - Europe/Kyiv
+          - Europe/Lisbon
+          - Europe/Ljubljana
+          - Europe/London
+          - Europe/Luxembourg
+          - Europe/Madrid
+          - Europe/Malta
+          - Europe/Mariehamn
+          - Europe/Minsk
+          - Europe/Monaco
+          - Europe/Moscow
+          - Europe/Nicosia
+          - Europe/Oslo
+          - Europe/Paris
+          - Europe/Podgorica
+          - Europe/Prague
+          - Europe/Riga
+          - Europe/Rome
+          - Europe/Samara
+          - Europe/San_Marino
+          - Europe/Sarajevo
+          - Europe/Saratov
+          - Europe/Simferopol
+          - Europe/Skopje
+          - Europe/Sofia
+          - Europe/Stockholm
+          - Europe/Tallinn
+          - Europe/Tirane
+          - Europe/Tiraspol
+          - Europe/Ulyanovsk
+          - Europe/Uzhgorod
+          - Europe/Vaduz
+          - Europe/Vatican
+          - Europe/Vienna
+          - Europe/Vilnius
+          - Europe/Volgograd
+          - Europe/Warsaw
+          - Europe/Zagreb
+          - Europe/Zaporozhye
+          - Europe/Zurich
+          - Factory
+          - GB
+          - GB-Eire
+          - GMT
+          - GMT+0
+          - GMT-0
+          - GMT0
+          - Greenwich
+          - HST
+          - Hongkong
+          - Iceland
+          - Indian/Antananarivo
+          - Indian/Chagos
+          - Indian/Christmas
+          - Indian/Cocos
+          - Indian/Comoro
+          - Indian/Kerguelen
+          - Indian/Mahe
+          - Indian/Maldives
+          - Indian/Mauritius
+          - Indian/Mayotte
+          - Indian/Reunion
+          - Iran
+          - Israel
+          - Jamaica
+          - Japan
+          - Kwajalein
+          - Libya
+          - MET
+          - MST
+          - MST7MDT
+          - Mexico/BajaNorte
+          - Mexico/BajaSur
+          - Mexico/General
+          - NZ
+          - NZ-CHAT
+          - Navajo
+          - PRC
+          - PST8PDT
+          - Pacific/Apia
+          - Pacific/Auckland
+          - Pacific/Bougainville
+          - Pacific/Chatham
+          - Pacific/Chuuk
+          - Pacific/Easter
+          - Pacific/Efate
+          - Pacific/Enderbury
+          - Pacific/Fakaofo
+          - Pacific/Fiji
+          - Pacific/Funafuti
+          - Pacific/Galapagos
+          - Pacific/Gambier
+          - Pacific/Guadalcanal
+          - Pacific/Guam
+          - Pacific/Honolulu
+          - Pacific/Johnston
+          - Pacific/Kanton
+          - Pacific/Kiritimati
+          - Pacific/Kosrae
+          - Pacific/Kwajalein
+          - Pacific/Majuro
+          - Pacific/Marquesas
+          - Pacific/Midway
+          - Pacific/Nauru
+          - Pacific/Niue
+          - Pacific/Norfolk
+          - Pacific/Noumea
+          - Pacific/Pago_Pago
+          - Pacific/Palau
+          - Pacific/Pitcairn
+          - Pacific/Pohnpei
+          - Pacific/Ponape
+          - Pacific/Port_Moresby
+          - Pacific/Rarotonga
+          - Pacific/Saipan
+          - Pacific/Samoa
+          - Pacific/Tahiti
+          - Pacific/Tarawa
+          - Pacific/Tongatapu
+          - Pacific/Truk
+          - Pacific/Wake
+          - Pacific/Wallis
+          - Pacific/Yap
+          - Poland
+          - Portugal
+          - ROC
+          - ROK
+          - Singapore
+          - Turkey
+          - UCT
+          - US/Alaska
+          - US/Aleutian
+          - US/Arizona
+          - US/Central
+          - US/East-Indiana
+          - US/Eastern
+          - US/Hawaii
+          - US/Indiana-Starke
+          - US/Michigan
+          - US/Mountain
+          - US/Pacific
+          - US/Samoa
+          - UTC
+          - Universal
+          - W-SU
+          - WET
+          - Zulu
+          - localtime
+          type: string
+        num_bonus_submissions:
+          description: ''
+          nullable: false
+          type: integer
+        total_submission_limit:
+          description: "The maximum number of times a Group can submit to\n      \
+            \      this Project EVER."
+          nullable: true
+          type: integer
+        allow_late_days:
+          description: "Whether to allow the use of late days for submitting\n   \
+            \         past the deadline."
+          nullable: false
+          type: boolean
+        ultimate_submission_policy:
+          description: "The \"ultimate\" submission for a group is the one\n     \
+            \       that will be used for final grading. This field specifies\n  \
+            \          how the ultimate submission should be determined."
+          nullable: false
+          enum:
+          - most_recent
+          - best_basic_score
+          - best
+          type: string
+        hide_ultimate_submission_fdbk:
+          description: "A hard override that indicates that ultimate\n           \
+            \ submission feedback should not be shown, even if the\n            appropriate\
+            \ criteria are met."
+          nullable: false
+          type: boolean
+        instructor_files:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/InstructorFile'
+        expected_student_files:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/ExpectedStudentFile'
+        has_handgrading_rubric:
+          description: Whether this project has a handgrading rubric.
+          type: boolean
+        send_email_on_submission_received:
+          description: "If True, users will receive a confirmation email\n       \
+            \     every time a submission of theirs is recorded in the\n         \
+            \   database."
+          nullable: false
+          type: boolean
+        send_email_on_non_deferred_tests_finished:
+          description: "If True, users will receive a confirmation email\n       \
+            \     once all non-deferred test cases for their submission are\n    \
+            \        finished grading."
+          nullable: false
+          type: boolean
+        use_honor_pledge:
+          description: "If True, then the frontend website should require\n      \
+            \      students to acknowledge an honor pledge. The text of the\n    \
+            \        honor pledge is stored in honor_pledge_text."
+          nullable: false
+          type: boolean
+        honor_pledge_text:
+          description: The text of the honor pledge to display.
+          nullable: false
+          type: string
+    UltimateSubmissionPolicy:
+      type: string
+      enum:
+      - most_recent
+      - best_basic_score
+      - best
+    ExpectedStudentFile:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        project:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        pattern:
+          description: "A shell-style file pattern suitable for\n            use with\
+            \ Python's fnmatch.fnmatch()\n            function (https://docs.python.org/3.5/library/fnmatch.html)\n\
+            \            This string must be a legal UNIX filename and may not be\n\
+            \            '..' or '.'.\n            NOTE: Patterns for a given project\
+            \ must not overlap,\n                otherwise the behavior is undefined."
+          nullable: false
+          type: string
+        min_num_matches:
+          description: "The minimum number of submitted student files that\n     \
+            \       should match the pattern. Must be non-negative."
+          nullable: false
+          type: integer
+        max_num_matches:
+          description: "The maximum number of submitted student files that\n     \
+            \       can match the pattern. Must be >= min_num_matches"
+          nullable: false
+          type: integer
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    InstructorFile:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        project:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        name:
+          description: ''
+          nullable: false
+          type: string
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        size:
+          description: ''
+          type: integer
+    DownloadTask:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        project:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        download_type:
+          description: ''
+          nullable: false
+          enum:
+          - all_scores
+          - final_graded_submission_scores
+          - all_submission_files
+          - final_graded_submission_files
+          type: string
+        result_filename:
+          description: ''
+          nullable: false
+          type: string
+        progress:
+          description: A percentage indicating how close the task is to completion.
+          nullable: false
+          type: integer
+        include_pending_extensions:
+          description: "Applies only to \"final_graded_submission_scores\" downloads,\n\
+            \            ignored otherwise. When True, students with pending extensions\
+            \ will be\n            included in final_graded_submission_scores download\
+            \ CSV files."
+          nullable: false
+          type: boolean
+        error_msg:
+          description: ''
+          nullable: false
+          type: string
+        created_at:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    DownloadType:
+      type: string
+      enum:
+      - all_scores
+      - final_graded_submission_scores
+      - all_submission_files
+      - final_graded_submission_files
+    Group:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        project:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        extended_due_date:
+          description: "When this field is set, it indicates that members\n      \
+            \      of this submission group can submit until this specified\n    \
+            \        date, overriding the project closing time.\n            Default\
+            \ value: None"
+          nullable: true
+          type: string
+          format: date-time
+        member_names:
+          description: A list of usernames of the group members, sorted alphabetically.
+          type: array
+          items:
+            type: string
+          readOnly: false
+        members:
+          description: "The Users that belong to this submission group.\n        \
+            \    This list must contain at least one member and no more than\n   \
+            \         project.max_group_size members. A User can only be a member\n\
+            \            of one submission group per project.\n            This field\
+            \ is REQUIRED."
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        bonus_submissions_remaining:
+          description: The number of unused bonus submission tokens this group has.
+          type: integer
+        late_days_used:
+          description: "Keeps track of how many late days each user in this\n    \
+            \        group has used.\n            Data format: {\n               \
+            \ \"\\<username\\>\": \\<num late days used\\>,\n                ...\n\
+            \            }\n            NOTE: This field is updated only when a group\
+            \ member uses a\n            late day. If a user is moved to another group\
+            \ or this group\n            is merged with another one, this field will\
+            \ NOT be updated."
+          nullable: false
+          type: object
+        num_submissions:
+          description: ''
+          type: integer
+        num_submits_towards_limit:
+          description: "The number of submissions this group has made in the current\
+            \ 24\n        hour period that are counted towards the daily submission\
+            \ limit."
+          type: integer
+        created_at:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    GroupInvitation:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        project:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        sender:
+          description: "The User who created this invitation.\n            This field\
+            \ is REQUIRED."
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/User'
+        recipients:
+          description: "The Users that the sender has invited\n            to form\
+            \ a submission group together.\n            This field is REQUIRED.\n\
+            \            This field may not be empty."
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        sender_username:
+          description: The username of the User that sent this invitation.
+          type: string
+        recipient_usernames:
+          description: The usernames of the Users that will receive this invitation.
+          type: array
+          items:
+            type: string
+        recipients_who_accepted:
+          description: "A list of usernames indicating which invitees have accepted\n\
+            \        this invitation.\n        This field is READ ONLY."
+          type: array
+          items:
+            type: string
+    Submission:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        group:
+          description: "The SubmissionGroup that this submission belongs to. Note\n\
+            \            that this field indirectly links this Submission object to\
+            \ a\n            Project.\n            This field is REQUIRED."
+          nullable: false
+          type: integer
+          format: id
+        timestamp:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        submitter:
+          description: The name of the user who made this submission
+          nullable: false
+          type: string
+        submitted_filenames:
+          description: "The names of files that were submitted,\n                \
+            \     excluding those that were discarded."
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: string
+        discarded_files:
+          description: The names of files that were discarded when this Submission
+            was created.
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: string
+        missing_files:
+          description: "Stores missing filenames and the additional number\n     \
+            \       of files needed to satisfy a file pattern requirement.\n     \
+            \       Stored as key-value pairs of the form:\n            {pattern:\
+            \ num_additional_needed}"
+          nullable: false
+          type: object
+        status:
+          description: "The grading status of this submission see\n            Submission.GradingStatus\
+            \ for details on allowed values."
+          nullable: false
+          enum:
+          - received
+          - queued
+          - being_graded
+          - waiting_for_deferred
+          - finished_grading
+          - removed_from_queue
+          - rejected
+          - error
+          type: string
+        is_past_daily_limit:
+          description: Whether this submission is past the daily submission limit.
+          nullable: false
+          type: boolean
+        is_bonus_submission:
+          description: "When True, indicates that the group that made this\n     \
+            \       submission should be able to request normal feedback for\n   \
+            \         this submission's results.\n            Note: If this field\
+            \ is True, is_past_daily_limit should be\n            False."
+          nullable: false
+          type: boolean
+        count_towards_total_limit:
+          description: Whether this submission should count towards the total submission
+            limit.
+          nullable: false
+          type: boolean
+        does_not_count_for:
+          description: "A list of users for whom this submission will NOT\n      \
+            \      count as their final graded submission. Users are added to\n  \
+            \          this list if they are out of late days and another group\n\
+            \            member (who still has late days remaining) uses their own\n\
+            \            late day to submit."
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: string
+        position_in_queue:
+          description: "Returns this submission's position in the queue of submissions\n\
+            \        to be graded for the associated project."
+          type: integer
+        grading_start_time:
+          description: The time that the submission was marked as being_graded.Can
+            be used to calculate time spent in queue.
+          nullable: true
+          type: string
+          format: date-time
+        non_deferred_grading_end_time:
+          description: The time that the submission was marked as waiting_for_deferred.Can
+            be used to calculate time spent grading non-deferred tests.
+          nullable: true
+          type: string
+          format: date-time
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    Command:
+      type: object
+      properties:
+        cmd:
+          description: "A string containing the command to be run.\n             \
+            \     Note: This string will be inserted into ['bash', '-c', <cmd>]\n\
+            \                     in order to be executed."
+          type: string
+        name:
+          description: An optional name for this command to be displayed to users.
+          type: string
+        time_limit:
+          description: "The time limit in seconds to be placed on the command.\n \
+            \           Must be > 0\n            Must be <= 90"
+          type: integer
+        stack_size_limit:
+          description: This field is IGNORED and will be removed in version 5.0.0.
+          type: integer
+        use_virtual_memory_limit:
+          description: "When set to false, the virtual memory limit will not\n   \
+            \         be applied to the command. Note that the sandbox will still\
+            \ apply\n            a physical memory limit to all commands run in the\
+            \ sandbox."
+          type: boolean
+        virtual_memory_limit:
+          description: "The maximum amount of virtual memory\n            (in bytes)\
+            \ the command can use. Must be > 0.\n            Limiting virtual memory\
+            \ can help produce cleaner\n            error messages when the command\
+            \ uses too much memory. However, some programs allocate\n            a\
+            \ large amount of virtual memory but use very little *physical* memory.\
+            \ For these\n            kinds of programs (e.g. Java programs), we recommend\
+            \ NOT limiting virtual memory.\n            Note that physical memory\
+            \ usage will still be limited for security reasons."
+          type: integer
+        block_process_spawn:
+          description: When true, prevents the command from spawning child processes.
+          type: boolean
+        process_spawn_limit:
+          description: "This field is IGNORED and will be removed in version 5.0.0.\n\
+            \            Use block_process_spawn instead."
+          type: integer
+    SandboxDockerImage:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        display_name:
+          description: "A human-readable name for this sandbox image.\n          \
+            \           Must be unique among images belonging to a course.\n     \
+            \                This field is required."
+          nullable: false
+          type: string
+        course:
+          description: The course this image is associated with.
+          nullable: true
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    BuildSandboxDockerImageTask:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        created_at:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        status:
+          description: The status of the build.
+          nullable: false
+          enum:
+          - queued
+          - in_progress
+          - done
+          - failed
+          - image_invalid
+          - cancelled
+          - internal_error
+          type: string
+        return_code:
+          description: The exit status of the build command.
+          nullable: true
+          type: integer
+        timed_out:
+          description: True if the build timed out.
+          nullable: false
+          type: boolean
+        filenames:
+          description: The names of the files uploaded by the user.
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: string
+        course_id:
+          description: "The course this task is associated with.\n            Only\
+            \ superusers can create or update images with no associated course."
+          nullable: true
+          type: integer
+          format: id
+        image:
+          description: "When initially null, indicates that a new image will be created.\n\
+            \            That new image will then be set as the value for this field.\n\
+            \n            When not null initially, indicates that the specified image\n\
+            \            should be updated when the build finishes."
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/SandboxDockerImage'
+        validation_error_msg:
+          description: Information for the user as to while the built image is invalid.
+          nullable: false
+          type: string
+        internal_error_msg:
+          description: If an internal error occurs, the error message will be stored
+            here.
+          nullable: false
+          type: string
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    BuildImageStatus:
+      type: string
+      enum:
+      - queued
+      - in_progress
+      - done
+      - failed
+      - image_invalid
+      - cancelled
+      - internal_error
+    AGTestSuite:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        name:
+          description: "The name used to identify this suite.\n                  \
+            \   Must be non-empty and non-null.\n                     Must be unique\
+            \ among suites that belong to the same project.\n                    \
+            \ This field is REQUIRED."
+          nullable: false
+          type: string
+        project:
+          description: "The project this suite belongs to.\n                     \
+            \                        This field is REQUIRED."
+          nullable: false
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        instructor_files_needed:
+          description: "The project files that will be copied into the sandbox before\
+            \ the suite's\n                     tests are run."
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/InstructorFile'
+        read_only_instructor_files:
+          description: "When True, project files needed for this suite will be read-only\
+            \ when this\n                     suite is run."
+          nullable: false
+          type: boolean
+        student_files_needed:
+          description: "Student-submitted files matching these patterns will be copied\
+            \ into the\n                     sandbox before the suite's tests are\
+            \ run."
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/ExpectedStudentFile'
+        ag_test_cases:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/AGTestCase'
+        setup_suite_cmd:
+          description: "A command to be run before this suite's tests are run.\n \
+            \                    This command is only run once at the beginning of\
+            \ the suite.\n                     This command will be run after the\
+            \ student and project files\n                     have been added to the\
+            \ sandbox.\n                     If this field is empty, then no setup\
+            \ command will be run."
+          nullable: false
+          type: string
+        setup_suite_cmd_name:
+          description: The name of this suite's setup command.
+          nullable: false
+          type: string
+        reject_submission_if_setup_fails:
+          description: "When this field is True and the suite has a setup command,\n\
+            \            the submission will be rejected if that setup command fails.\n\
+            \            This field is only allowed to be True for the first non-deferred\
+            \ AGTestSuite\n            (order specified by Project.get_agtestsuite_order())\
+            \ of the Project."
+          nullable: false
+          type: boolean
+        sandbox_docker_image:
+          description: The sandbox docker image to use for running this suite.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/SandboxDockerImage'
+        allow_network_access:
+          description: "Specifies whether the sandbox should allow commands run inside\
+            \ of it to\n                     make network calls outside of the sandbox."
+          nullable: false
+          type: boolean
+        deferred:
+          description: "If true, this test suite can be graded asynchronously. Deferred\
+            \ suites that\n                     have yet to be graded do not prevent\
+            \ members of a group from submitting\n                     again."
+          nullable: false
+          type: boolean
+        normal_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+        ultimate_submission_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+        past_limit_submission_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+        staff_viewer_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestSuiteFeedbackConfig'
+    AGTestSuiteFeedbackConfig:
+      type: object
+      properties:
+        visible:
+          description: ''
+          type: boolean
+        show_individual_tests:
+          description: Whether to show information about individual tests in a suite
+            or just a points summary (if available).
+          type: boolean
+        show_setup_return_code:
+          description: ''
+          type: boolean
+        show_setup_timed_out:
+          description: ''
+          type: boolean
+        show_setup_stdout:
+          description: Whether to show stdout content from a suite's setup command.
+          type: boolean
+        show_setup_stderr:
+          description: Whether to show stderr content from a suite's setup command.
+          type: boolean
+    AGTestCase:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        name:
+          description: "The name used to identify this autograder test.\n        \
+            \             Must be non-empty and non-null.\n                     Must\
+            \ be unique among autograder tests that belong to the same suite.\n  \
+            \                   This field is REQUIRED."
+          nullable: false
+          type: string
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        ag_test_suite:
+          description: "The suite this autograder test belongs to.\n             \
+            \        This field is REQUIRED."
+          nullable: false
+          type: integer
+          format: id
+        ag_test_commands:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/AGTestCommand'
+        normal_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+        ultimate_submission_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+        past_limit_submission_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+        staff_viewer_fdbk_config:
+          description: ''
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCaseFeedbackConfig'
+    AGTestCaseFeedbackConfig:
+      type: object
+      properties:
+        visible:
+          description: ''
+          type: boolean
+        show_individual_commands:
+          description: ''
+          type: boolean
+    AGTestCommand:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        name:
+          description: "The name used to identify this command.\n                \
+            \         Must be non-empty and non-null.\n                         Must\
+            \ be unique among commands that belong to the same autograder test.\n\
+            \                         This field is REQUIRED."
+          nullable: false
+          type: string
+        ag_test_case:
+          description: The AGTestCase that this command belongs to.
+          nullable: false
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        cmd:
+          description: "A string containing the command to be run.\n             \
+            \        Note: This string will be inserted into ['bash', '-c', <cmd>]\n\
+            \                        in order to be executed.\n                  \
+            \   Note: This string defaults to the \"true\" command\n             \
+            \        (which does nothing and returns 0) so that AGCommands are\n \
+            \                    default-creatable."
+          nullable: false
+          type: string
+        stdin_source:
+          description: Specifies what kind of source stdin will be redirected from.
+          nullable: false
+          enum:
+          - none
+          - text
+          - instructor_file
+          - setup_stdout
+          - setup_stderr
+          type: string
+        stdin_text:
+          description: "A string whose contents should be redirected to the stdin\
+            \ of this command.\n                     This value is used when stdin_source\
+            \ is StdinSource.text and is ignored\n                     otherwise."
+          nullable: false
+          type: string
+        stdin_instructor_file:
+          description: "An InstructorFile whose contents should be redirected to the\
+            \ stdin of this\n                     command. This value is used when\
+            \ stdin_source is StdinSource.instructor_file\n                     and\
+            \ is ignored otherwise."
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/InstructorFile'
+        expected_return_code:
+          description: Specifies the command's expected return code.
+          nullable: false
+          enum:
+          - none
+          - zero
+          - nonzero
+          type: string
+        expected_stdout_source:
+          description: Specifies what kind of source this command's stdout should
+            be compared to.
+          nullable: false
+          enum:
+          - none
+          - text
+          - instructor_file
+          type: string
+        expected_stdout_text:
+          description: "A string whose contents should be compared against this command's\
+            \ stdout.\n                     This value is used when expected_stdout_source\
+            \ is ExpectedOutputSource.text\n                     and is ignored otherwise."
+          nullable: false
+          type: string
+        expected_stdout_instructor_file:
+          description: "An InstructorFile whose contents should be compared against\
+            \ this command's\n                     stdout. This value is used (and\
+            \ may not be null) when expected_stdout_source\n                     is\
+            \ ExpectedOutputSource.instructor_file and is ignored otherwise."
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/InstructorFile'
+        expected_stderr_source:
+          description: Specifies what kind of source this command's stderr should
+            be compared to.
+          nullable: false
+          enum:
+          - none
+          - text
+          - instructor_file
+          type: string
+        expected_stderr_text:
+          description: "A string whose contents should be compared against this command's\
+            \ stderr.\n                     This value is used when expected_stderr_source\
+            \ is ExpectedOutputSource.text\n                     and is ignored otherwise."
+          nullable: false
+          type: string
+        expected_stderr_instructor_file:
+          description: "An InstructorFile whose contents should be compared against\
+            \ this command's\n                     stderr. This value is used (and\
+            \ may not be null) when expected_stderr_source\n                     is\
+            \ ExpectedOutputSource.instructor_file and is ignored otherwise."
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/InstructorFile'
+        ignore_case:
+          description: Ignore case when checking output. Equivalent to diff -i
+          nullable: false
+          type: boolean
+        ignore_whitespace:
+          description: Ignore inline whitespace when checking output. Equivalent to
+            diff -w
+          nullable: false
+          type: boolean
+        ignore_whitespace_changes:
+          description: Ignore whitespace changes when checking output. Equivalent
+            to diff -b
+          nullable: false
+          type: boolean
+        ignore_blank_lines:
+          description: Ignore changes in blank lines when checking output. Equivalent
+            to diff -B
+          nullable: false
+          type: boolean
+        points_for_correct_return_code:
+          description: "The number of points to be awarded when this command\n   \
+            \                  produces the correct return_code"
+          nullable: false
+          type: integer
+        points_for_correct_stdout:
+          description: "The number of points to be awarded when this command\n   \
+            \                  produces the correct stdout"
+          nullable: false
+          type: integer
+        points_for_correct_stderr:
+          description: "The number of points to be awarded when this command\n   \
+            \                  produces the correct stderr"
+          nullable: false
+          type: integer
+        deduction_for_wrong_return_code:
+          description: "The number of points to deduct when this command\n       \
+            \              produces the wrong return code (this value must be negative).\n\
+            \                     Note: The total points given for a single command\
+            \ may be negative,\n                     but the total points for an AGTestCase\
+            \ will be capped at zero."
+          nullable: false
+          type: integer
+        deduction_for_wrong_stdout:
+          description: "The number of points to deduct when this command\n       \
+            \              produces the wrong stdout (this value must be negative).\n\
+            \                     Note: The total points given for a single command\
+            \ may be negative,\n                     but the total points for an AGTestCase\
+            \ will be capped at zero."
+          nullable: false
+          type: integer
+        deduction_for_wrong_stderr:
+          description: "The number of points to deduct when this command\n       \
+            \              produces the wrong stderr (this value must be negative).\n\
+            \                     Note: The total points given for a single command\
+            \ may be negative,\n                     but the total points for an AGTestCase\
+            \ will be capped at zero."
+          nullable: false
+          type: integer
+        normal_fdbk_config:
+          description: Feedback settings for a normal Submission.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+        first_failed_test_normal_fdbk_config:
+          description: "When non-null, specifies feedback to be given when\n     \
+            \                this command is in the first test case that failed\n\
+            \                     within a suite."
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+        ultimate_submission_fdbk_config:
+          description: Feedback settings for an ultimate Submission.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+        past_limit_submission_fdbk_config:
+          description: Feedback settings for a Submission that is past the daily limit.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+        staff_viewer_fdbk_config:
+          description: Feedback settings for a staff member viewing a Submission from
+            another group.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/AGTestCommandFeedbackConfig'
+        time_limit:
+          description: "The time limit in seconds to be placed on the command.\n \
+            \           Must be > 0\n            Must be <= 90"
+          nullable: false
+          type: integer
+        use_virtual_memory_limit:
+          description: "When set to false, the virtual memory limit will not\n   \
+            \         be applied to the command. Note that the sandbox will still\
+            \ apply\n            a physical memory limit to all commands run in the\
+            \ sandbox."
+          nullable: false
+          type: boolean
+        virtual_memory_limit:
+          description: "The maximum amount of virtual memory\n            (in bytes)\
+            \ the command can use. Must be > 0.\n            Limiting virtual memory\
+            \ can help produce cleaner\n            error messages when the command\
+            \ uses too much memory. However, some programs allocate\n            a\
+            \ large amount of virtual memory but use very little *physical* memory.\
+            \ For these\n            kinds of programs (e.g. Java programs), we recommend\
+            \ NOT limiting virtual memory.\n            Note that physical memory\
+            \ usage will still be limited for security reasons."
+          nullable: false
+          type: integer
+        block_process_spawn:
+          description: When true, prevents the command from spawning child processes.
+          nullable: false
+          type: boolean
+    AGTestCommandFeedbackConfig:
+      type: object
+      properties:
+        visible:
+          description: ''
+          type: boolean
+        return_code_fdbk_level:
+          description: ''
+          $ref: '#/components/schemas/ValueFeedbackLevel'
+        stdout_fdbk_level:
+          description: ''
+          $ref: '#/components/schemas/ValueFeedbackLevel'
+        stderr_fdbk_level:
+          description: ''
+          $ref: '#/components/schemas/ValueFeedbackLevel'
+        show_points:
+          description: ''
+          type: boolean
+        show_actual_return_code:
+          description: ''
+          type: boolean
+        show_actual_stdout:
+          description: ''
+          type: boolean
+        show_actual_stderr:
+          description: ''
+          type: boolean
+        show_whether_timed_out:
+          description: ''
+          type: boolean
+    StdinSource:
+      type: string
+      enum:
+      - none
+      - text
+      - instructor_file
+      - setup_stdout
+      - setup_stderr
+    ExpectedOutputSource:
+      type: string
+      enum:
+      - none
+      - text
+      - instructor_file
+    ExpectedReturnCode:
+      type: string
+      enum:
+      - none
+      - zero
+      - nonzero
+    ValueFeedbackLevel:
+      type: string
+      enum:
+      - no_feedback
+      - correct_or_incorrect
+      - expected_and_actual
+    SubmissionResultFeedback:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        total_points:
+          description: ''
+          anyOf:
+          - type: integer
+          - type: string
+            format: float
+        total_points_possible:
+          description: ''
+          anyOf:
+          - type: integer
+          - type: string
+            format: float
+        ag_test_suite_results:
+          description: ''
+          type: array
+          items:
+            $ref: '#/components/schemas/AGTestSuiteResultFeedback'
+        mutation_test_suite_results:
+          description: ''
+          type: array
+          items:
+            $ref: '#/components/schemas/MutationTestSuiteResultFeedback'
+    AGTestSuiteResultFeedback:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        ag_test_suite_name:
+          description: ''
+          type: string
+        ag_test_suite_pk:
+          description: ''
+          type: integer
+        fdbk_settings:
+          description: ''
+          type: object
+        total_points:
+          description: ''
+          type: integer
+        total_points_possible:
+          description: ''
+          type: integer
+        setup_name:
+          description: ''
+          nullable: true
+          type: string
+        setup_return_code:
+          description: ''
+          nullable: true
+          type: integer
+        setup_timed_out:
+          description: ''
+          nullable: true
+          type: boolean
+        ag_test_case_results:
+          description: ''
+          type: array
+          items:
+            $ref: '#/components/schemas/AGTestCaseResultFeedback'
+    AGTestCaseResultFeedback:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        ag_test_case_name:
+          description: ''
+          type: string
+        ag_test_case_pk:
+          description: ''
+          type: integer
+        fdbk_settings:
+          description: ''
+          type: object
+        total_points:
+          description: ''
+          type: integer
+        total_points_possible:
+          description: ''
+          type: integer
+        ag_test_command_results:
+          description: ''
+          type: array
+          items:
+            $ref: '#/components/schemas/AGTestCommandResultFeedback'
+    AGTestCommandResultFeedback:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        ag_test_command_pk:
+          description: ''
+          type: integer
+        ag_test_command_name:
+          description: ''
+          type: string
+        fdbk_settings:
+          description: ''
+          type: object
+        timed_out:
+          description: ''
+          nullable: true
+          type: boolean
+        return_code_correct:
+          description: ''
+          nullable: true
+          type: boolean
+        expected_return_code:
+          description: ''
+          nullable: true
+          anyOf:
+          - $ref: '#/components/schemas/ExpectedReturnCode'
+        actual_return_code:
+          description: ''
+          nullable: true
+          type: integer
+        return_code_points:
+          description: ''
+          type: integer
+        return_code_points_possible:
+          description: ''
+          type: integer
+        stdout_correct:
+          description: ''
+          nullable: true
+          type: boolean
+        stdout_points:
+          description: ''
+          type: integer
+        stdout_points_possible:
+          description: ''
+          type: integer
+        stderr_correct:
+          description: ''
+          nullable: true
+          type: boolean
+        stderr_points:
+          description: ''
+          type: integer
+        stderr_points_possible:
+          description: ''
+          type: integer
+        total_points:
+          description: ''
+          type: integer
+        total_points_possible:
+          description: ''
+          type: integer
+    FeedbackCategory:
+      type: string
+      enum:
+      - normal
+      - ultimate_submission
+      - past_limit_submission
+      - staff_viewer
+      - max
+    MutationTestSuite:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        name:
+          description: "The name used to identify this MutationTestSuite.\n      \
+            \               Must be non-empty and non-null."
+          nullable: false
+          type: string
+        project:
+          description: The Project that this mutation test suite belongs to.
+          nullable: false
+          type: integer
+          format: id
+        instructor_files_needed:
+          description: "The project files that will be copied into the sandbox before\
+            \ the suite\n                     is graded."
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/InstructorFile'
+        read_only_instructor_files:
+          description: "When True, project files needed for this suite will be read-only\
+            \ when this\n                     suite is graded."
+          nullable: false
+          type: boolean
+        student_files_needed:
+          description: "Student-submitted files matching these patterns will be copied\
+            \ into the\n                     sandbox before the suite is graded."
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/ExpectedStudentFile'
+        buggy_impl_names:
+          description: The names of buggy implementations that student tests should
+            be run against.
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: string
+        use_setup_command:
+          description: ''
+          nullable: false
+          type: boolean
+        setup_command:
+          description: "A command to be run after student and project files have\n\
+            \                     been added to the sandbox but before any other commands\
+            \ are run.\n                     To indicate that no setup command should\
+            \ be run,\n                     set use_setup_command to False."
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Command'
+        get_student_test_names_command:
+          description: "This required command should print out a list of student\n\
+            \             test case names. The test case names should not be wrapped\n\
+            \             in quotes, even if the test names contain spaces.\n    \
+            \         If test_name_discovery_whitespace_handling is set to\n     \
+            \        'any_whitespace', the output of this command will be parsed using\n\
+            \             Python's str.split(). If set to 'newline', the output will\n\
+            \             be parsed using Python's str.splitlines(), and leading and\
+            \ trailing\n             whitespace will be stripped from each line."
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Command'
+        test_name_discovery_whitespace_handling:
+          description: ''
+          nullable: false
+          enum:
+          - newline
+          - any_whitespace
+          type: string
+        max_num_student_tests:
+          description: "The maximum number of test cases students are allowed to submit.\n\
+            \                     If more than this many tests are discovered by the\n\
+            \                     get_student_test_names_command, test names will\
+            \ be discarded\n                     from the end of that list."
+          nullable: false
+          type: integer
+        student_test_validity_check_command:
+          description: "This command will be run once for each detected student test\
+            \ case.\n                     An exit status of zero indicates that a\
+            \ student test case is valid,\n                     whereas a nonzero\
+            \ exit status indicates that a student test case\n                   \
+            \  is invalid.\n                     This command must contain the placeholder\
+            \ ${student_test_name} at least once. That\n                     placeholder\
+            \ will be replaced with the name of the student test case\n          \
+            \           that is to be checked for validity."
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Command'
+        grade_buggy_impl_command:
+          description: "This command will be run at least once for every buggy implementation.\n\
+            \            A nonzero exit status indicates that the valid student tests\
+            \ exposed the\n            buggy impl, whereas an exit status of zero\
+            \ indicates that the student\n            tests did not expose the buggy\
+            \ impl.\n\n            This command must contain the placeholders ${buggy_impl_name}\n\
+            \            and one of ${student_test_name} or ${all_valid_test_names}.\n\
+            \            The placeholder ${buggy_impl_name} will be replaced with\
+            \ the name of\n            the buggy impl that the student test is being\
+            \ run against.\n            If the placeholder ${student_test_name} is\
+            \ present,\n            it will be replaced with the name of a single\
+            \ valid student test case,\n            and the command will be run once\
+            \ for every (buggy implementation, valid test) pair.\n            If the\
+            \ placeholder ${all_valid_test_names} is present,\n            it will\
+            \ be replaced with the individually-quoted names of all valid\n      \
+            \      student tests, and the command will be run once for each buggy\
+            \ implementation.\n\n            This latter approach can potentially\
+            \ reduce the runtime (e.g., by\n            reducing the number of times\
+            \ an interpreter is invoked).\n            Note that you may need to specify\
+            \ a higher time limit with this strategy--for\n            example, if\
+            \ each individual test takes 1 second to run and running\n           \
+            \ 10 tests at once takes 10 seconds, the time limit will need to be\n\
+            \            more than 10 seconds, otherwise buggy impls could be erroneously\n\
+            \            marked as exposed due to the tests exceeding a low time limit."
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Command'
+        points_per_exposed_bug:
+          description: "The number of points to be awarded per buggy implementation\
+            \ exposed by\n                     the student test cases. This field\
+            \ is limited to 4 digits total and a maximum\n                     of\
+            \ 2 decimal places."
+          nullable: false
+          type: string
+          format: float
+        max_points:
+          description: An optional ceiling on the number of points to be awarded.
+          nullable: true
+          type: integer
+        deferred:
+          description: "If true, this mutation test suite can be graded asynchronously.\n\
+            \                     Deferred suites that have yet to be graded do not\
+            \ prevent members\n                     of a group from submitting again."
+          nullable: false
+          type: boolean
+        sandbox_docker_image:
+          description: The sandbox docker image to use for running this suite.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/SandboxDockerImage'
+        allow_network_access:
+          description: "Specifies whether the sandbox should allow commands run inside\
+            \ of it to\n                     make network calls outside of the sandbox."
+          nullable: false
+          type: boolean
+        normal_fdbk_config:
+          description: Feedback settings for a normal Submission.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+        ultimate_submission_fdbk_config:
+          description: Feedback settings for an ultimate Submission.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+        past_limit_submission_fdbk_config:
+          description: Feedback settings for a Submission that is past the daily limit.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+        staff_viewer_fdbk_config:
+          description: Feedback settings for a staff member viewing a Submission from
+            another group.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/MutationTestSuiteFeedbackConfig'
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    MutationTestSuiteFeedbackConfig:
+      type: object
+      properties:
+        visible:
+          description: ''
+          type: boolean
+        show_setup_return_code:
+          description: ''
+          type: boolean
+        show_setup_stdout:
+          description: ''
+          type: boolean
+        show_setup_stderr:
+          description: ''
+          type: boolean
+        show_get_test_names_return_code:
+          description: ''
+          type: boolean
+        show_get_test_names_stdout:
+          description: ''
+          type: boolean
+        show_get_test_names_stderr:
+          description: ''
+          type: boolean
+        show_validity_check_stdout:
+          description: ''
+          type: boolean
+        show_validity_check_stderr:
+          description: ''
+          type: boolean
+        show_grade_buggy_impls_stdout:
+          description: ''
+          type: boolean
+        show_grade_buggy_impls_stderr:
+          description: ''
+          type: boolean
+        show_invalid_test_names:
+          description: ''
+          type: boolean
+        show_points:
+          description: ''
+          type: boolean
+        bugs_exposed_fdbk_level:
+          description: ''
+          $ref: '#/components/schemas/BugsExposedFeedbackLevel'
+    BugsExposedFeedbackLevel:
+      type: string
+      enum:
+      - no_feedback
+      - num_bugs_exposed
+      - exposed_bug_names
+      - all_bug_names
+    MutationTestSuiteResultFeedback:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        mutation_test_suite_name:
+          description: ''
+          type: string
+        mutation_test_suite_pk:
+          description: ''
+          type: integer
+        fdbk_settings:
+          description: A dictionary representation of this object's feedback config.
+          type: object
+        has_setup_command:
+          description: ''
+          type: boolean
+        setup_command_name:
+          description: ''
+          nullable: true
+          type: string
+        setup_return_code:
+          description: ''
+          nullable: true
+          type: integer
+        setup_timed_out:
+          description: ''
+          nullable: true
+          type: boolean
+        get_student_test_names_return_code:
+          description: ''
+          nullable: true
+          type: integer
+        get_student_test_names_timed_out:
+          description: ''
+          nullable: true
+          type: boolean
+        student_tests:
+          description: ''
+          type: array
+          items:
+            type: string
+        discarded_tests:
+          description: ''
+          type: array
+          items:
+            type: string
+        invalid_tests:
+          description: ''
+          nullable: true
+          type: array
+          items:
+            type: string
+        timed_out_tests:
+          description: ''
+          nullable: true
+          type: array
+          items:
+            type: string
+        num_bugs_exposed:
+          description: ''
+          nullable: true
+          type: integer
+        bugs_exposed:
+          description: ''
+          nullable: true
+          type: array
+          items:
+            type: string
+        all_bug_names:
+          description: ''
+          nullable: true
+          type: array
+          items:
+            type: string
+        total_points:
+          description: ''
+          type: string
+          format: float
+        total_points_possible:
+          description: ''
+          type: string
+          format: float
+    RerunSubmissionsTask:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        progress:
+          description: ''
+          type: integer
+        is_cancelled:
+          description: Indicates whether the task has been cancelled by the user.
+          nullable: false
+          type: boolean
+        error_msg:
+          description: ''
+          nullable: false
+          type: string
+        creator:
+          description: ''
+          nullable: true
+          type: integer
+          format: id
+        created_at:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        has_error:
+          description: ''
+          type: boolean
+        project:
+          description: The Project this task belongs to.
+          nullable: false
+          type: integer
+          format: id
+        rerun_all_submissions:
+          description: "When True, indicates that all submissions for the specified\n\
+            \                     project should be rerun. Otherwise, only the submissions\n\
+            \                     whose primary keys are listed in submission_pks\
+            \ should be rerun."
+          nullable: false
+          type: boolean
+        submission_pks:
+          description: "When rerun_all_submissions is False, specifies which submissions\n\
+            \                     should be rerun."
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: integer
+        rerun_all_ag_test_suites:
+          description: "When True, indicates that all AGTestSuites belonging\n   \
+            \                  to the specified project should be rerun. Otherwise,\n\
+            \                     only the AGTestSuites specified in ag_test_suite_data\
+            \ should\n                     be rerun."
+          nullable: false
+          type: boolean
+        ag_test_suite_data:
+          description: "When rerun_all_ag_test_suites is False, specifies which\n\
+            \                     AGTestSuites should be rerun and which AGTestCases\
+            \ within\n                     those suites should be rerun.\n\n     \
+            \   Data format:\n        {\n            // Note: JSON format requires\
+            \ that keys are strings. Postgres\n            // doesn't seem to care,\
+            \ but some JSON serializers might.\n            \"<ag_test_suite_pk>\"\
+            : [<ag_test_case_pk>, ...],\n            ...\n        }\n\n        If\
+            \ an ag_test_suite_pk is mapped to an empty list, then all ag test cases\n\
+            \        belonging to that ag test suite will be rerun."
+          nullable: false
+          type: object
+        rerun_all_mutation_test_suites:
+          description: "When True, indicates that all MutationTestSuites belonging\n\
+            \                     to the specified project should be rerun. Otherwise,\n\
+            \                     only the MutationTestSuites specified in mutation_test_suite_pks\n\
+            \                     should be rerun."
+          nullable: false
+          type: boolean
+        mutation_suite_pks:
+          description: "When rerun_all_mutation_test_suites is False, specifies which\n\
+            \                     mutation test suites should be rerun."
+          nullable: false
+          type: array
+          items:
+            description: ''
+            nullable: false
+            type: integer
+    HandgradingRubric:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        project:
+          description: The Project this HandgradingRubric belongs to.
+          nullable: false
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        points_style:
+          description: "Determines how total_points and total_possible_points are\
+            \ calculated\n                     for HandgradingResults."
+          nullable: false
+          enum:
+          - start_at_zero_and_add
+          - start_at_max_and_subtract
+          type: string
+        max_points:
+          description: "The denominator of a handgrading score.\n                \
+            \     When points_style is \"start_at_zero_and_add\", this value\n   \
+            \                  overrides the sum of positive Criteria point values\
+            \ as the\n                     total points possible.\n              \
+            \       When points_style is \"start_at_max_and_subtract\", this field\n\
+            \                     is REQUIRED."
+          nullable: true
+          type: number
+        show_grades_and_rubric_to_students:
+          description: "Whether students can see their handgrading scores,\n     \
+            \                including information from the rubric."
+          nullable: false
+          type: boolean
+        show_only_applied_rubric_to_students:
+          description: "Whether students can see rubric items that\n             \
+            \        were not applied to their submission."
+          nullable: false
+          type: boolean
+        handgraders_can_leave_comments:
+          description: Whether handgraders can add comments to a HandgradingResult.
+          nullable: false
+          type: boolean
+        handgraders_can_adjust_points:
+          description: Whether handgraders can edit HandgradingResult.point_adjustment.
+          nullable: false
+          type: boolean
+        criteria:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/Criterion'
+        annotations:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/Annotation'
+    PointsStyle:
+      type: string
+      enum:
+      - start_at_zero_and_add
+      - start_at_max_and_subtract
+    Criterion:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        handgrading_rubric:
+          description: The rubric this Criterion belongs to.
+          nullable: false
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        short_description:
+          description: A short description of this Criterion.
+          nullable: false
+          type: string
+        long_description:
+          description: "A long description of this Criterion. Note that there is no\n\
+            \                     enforced length difference between short_ and long_description.\n\
+            \                     The separation is purely to be used by clients."
+          nullable: false
+          type: string
+        points:
+          description: "The amount of points to add or subtract from a handgrading\
+            \ score\n                     when selected."
+          nullable: false
+          type: number
+    Annotation:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        handgrading_rubric:
+          description: The HandgradingRubric this Annotation belongs to.
+          nullable: false
+          type: integer
+          format: id
+        short_description:
+          description: A short description of this Annotation.
+          nullable: false
+          type: string
+        long_description:
+          description: "A long description of this Criterion. Note that there is no\n\
+            \                     enforced length difference between short_ and long_description.\n\
+            \                     The separation is purely to be used by clients."
+          nullable: false
+          type: string
+        deduction:
+          description: "The amount of points to deduct from a handgrading score when\n\
+            \                     applied. Must be non-positive."
+          nullable: false
+          type: number
+        max_deduction:
+          description: "The maximum amount of points that can be cumulatively\n  \
+            \                   deducted from a handgrading score by applications\
+            \ of\n                     this annotation. Must be None or non-positive."
+          nullable: true
+          type: number
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    HandgradingResult:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        submission:
+          description: The specific submission that is being handgraded.
+          nullable: false
+          type: integer
+          format: id
+        handgrading_rubric:
+          description: The HandgradingRubric that this HandgradingResult is based
+            on.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/HandgradingRubric'
+        group:
+          description: The SubmissionGroup that this HandgradingResult is for.
+          nullable: false
+          type: integer
+          format: id
+        applied_annotations:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/AppliedAnnotation'
+        comments:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/Comment'
+        criterion_results:
+          description: ''
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/CriterionResult'
+        finished_grading:
+          description: "Handgraders should set this field to True when they are finished\n\
+            \                     grading this group's submission."
+          nullable: false
+          type: boolean
+        points_adjustment:
+          description: "An arbitrary adjustment to this result's total points.\n \
+            \                    Note that this does not affect total points possible."
+          nullable: false
+          type: number
+        submitted_filenames:
+          description: "Returns a list of strings containing the filenames of the\
+            \ Submission this result\n        belongs to.\n\n        If any of the\
+            \ filenames have the .zip extension, will attempt to include the paths\n\
+            \        of files inside the zip archive. These entries will be of the\
+            \ form:\n            {zip_filename}/zip/member/path\n\n        For example,\
+            \ if a file \"submission.zip\" was submitted that contains a file\n  \
+            \      called \"tests.py\", the entry for tests.py would be:\n       \
+            \     submission.zip/tests.py"
+          type: array
+          items:
+            type: string
+        total_points:
+          description: "The total number of points awarded. Note that it is possible\n\
+            \        for this value to be greater than total_points."
+          type: number
+        total_points_possible:
+          description: "The denominator of the handgrading score based on the\n  \
+            \      handgrading rubric's points style and max points."
+          type: number
+    CriterionResult:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        selected:
+          description: "When True, indicates that the criterion's point allotment\
+            \ should be\n                     added to (or subtracted from if negative)\
+            \ the total handgrading points."
+          nullable: false
+          type: boolean
+        criterion:
+          description: The Criterion that the CriterionResult is tied to.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Criterion'
+        handgrading_result:
+          description: The HandgradingResult this CriterionResult belongs to.
+          nullable: false
+          type: integer
+          format: id
+    AppliedAnnotation:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        location:
+          description: The source code location where the Annotation was applied.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Location'
+        annotation:
+          description: The Annotation that was applied to the source code.
+          nullable: false
+          allOf:
+          - $ref: '#/components/schemas/Annotation'
+        handgrading_result:
+          description: The HandgradingResult the applied annotation belongs to.
+          nullable: false
+          type: integer
+          format: id
+    Comment:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        location:
+          description: "When not None, specifies the source code location this comment\n\
+            \                     applies to."
+          nullable: true
+          allOf:
+          - $ref: '#/components/schemas/Location'
+        text:
+          description: Text to be shown to students.
+          nullable: false
+          type: string
+        handgrading_result:
+          description: The HandgradingResult that this Comment belongs to.
+          nullable: false
+          type: integer
+          format: id
+    Location:
+      type: object
+      properties:
+        filename:
+          description: The file that contains the source code region.
+          type: string
+        first_line:
+          description: The first line in the source code region. Must be non-negative.
+          type: integer
+        last_line:
+          description: The last line in the source code region (inclusive). Must be
+            non-negative.
+          type: integer
+    MutationTestSuiteHintConfig:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        mutation_test_suite:
+          description: The mutation test suite that these hints are configured for.
+          nullable: false
+          type: integer
+          format: id
+        hints_by_mutant_name:
+          description: A mapping of mutant names to list of hints.
+          nullable: false
+          type: object
+        num_hints_per_day:
+          description: The number of hints a student is allowed to unlock per submission
+            for this mutation test suite in a 24 hour period. None indicates no limit.
+          nullable: true
+          type: integer
+        hint_limit_reset_time:
+          description: "The time at which the number of hints a group\n          \
+            \           has unlocked resets. Defaults to 00:00:00."
+          nullable: false
+          type: string
+          format: time
+        hint_limit_reset_timezone:
+          description: "A string representing the timezone to use when computing\n\
+            \            how many hints a group has unlocked in a 24 hour period."
+          nullable: false
+          enum:
+          - Africa/Abidjan
+          - Africa/Accra
+          - Africa/Addis_Ababa
+          - Africa/Algiers
+          - Africa/Asmara
+          - Africa/Asmera
+          - Africa/Bamako
+          - Africa/Bangui
+          - Africa/Banjul
+          - Africa/Bissau
+          - Africa/Blantyre
+          - Africa/Brazzaville
+          - Africa/Bujumbura
+          - Africa/Cairo
+          - Africa/Casablanca
+          - Africa/Ceuta
+          - Africa/Conakry
+          - Africa/Dakar
+          - Africa/Dar_es_Salaam
+          - Africa/Djibouti
+          - Africa/Douala
+          - Africa/El_Aaiun
+          - Africa/Freetown
+          - Africa/Gaborone
+          - Africa/Harare
+          - Africa/Johannesburg
+          - Africa/Juba
+          - Africa/Kampala
+          - Africa/Khartoum
+          - Africa/Kigali
+          - Africa/Kinshasa
+          - Africa/Lagos
+          - Africa/Libreville
+          - Africa/Lome
+          - Africa/Luanda
+          - Africa/Lubumbashi
+          - Africa/Lusaka
+          - Africa/Malabo
+          - Africa/Maputo
+          - Africa/Maseru
+          - Africa/Mbabane
+          - Africa/Mogadishu
+          - Africa/Monrovia
+          - Africa/Nairobi
+          - Africa/Ndjamena
+          - Africa/Niamey
+          - Africa/Nouakchott
+          - Africa/Ouagadougou
+          - Africa/Porto-Novo
+          - Africa/Sao_Tome
+          - Africa/Timbuktu
+          - Africa/Tripoli
+          - Africa/Tunis
+          - Africa/Windhoek
+          - America/Adak
+          - America/Anchorage
+          - America/Anguilla
+          - America/Antigua
+          - America/Araguaina
+          - America/Argentina/Buenos_Aires
+          - America/Argentina/Catamarca
+          - America/Argentina/ComodRivadavia
+          - America/Argentina/Cordoba
+          - America/Argentina/Jujuy
+          - America/Argentina/La_Rioja
+          - America/Argentina/Mendoza
+          - America/Argentina/Rio_Gallegos
+          - America/Argentina/Salta
+          - America/Argentina/San_Juan
+          - America/Argentina/San_Luis
+          - America/Argentina/Tucuman
+          - America/Argentina/Ushuaia
+          - America/Aruba
+          - America/Asuncion
+          - America/Atikokan
+          - America/Atka
+          - America/Bahia
+          - America/Bahia_Banderas
+          - America/Barbados
+          - America/Belem
+          - America/Belize
+          - America/Blanc-Sablon
+          - America/Boa_Vista
+          - America/Bogota
+          - America/Boise
+          - America/Buenos_Aires
+          - America/Cambridge_Bay
+          - America/Campo_Grande
+          - America/Cancun
+          - America/Caracas
+          - America/Catamarca
+          - America/Cayenne
+          - America/Cayman
+          - America/Chicago
+          - America/Chihuahua
+          - America/Ciudad_Juarez
+          - America/Coral_Harbour
+          - America/Cordoba
+          - America/Costa_Rica
+          - America/Creston
+          - America/Cuiaba
+          - America/Curacao
+          - America/Danmarkshavn
+          - America/Dawson
+          - America/Dawson_Creek
+          - America/Denver
+          - America/Detroit
+          - America/Dominica
+          - America/Edmonton
+          - America/Eirunepe
+          - America/El_Salvador
+          - America/Ensenada
+          - America/Fort_Nelson
+          - America/Fort_Wayne
+          - America/Fortaleza
+          - America/Glace_Bay
+          - America/Godthab
+          - America/Goose_Bay
+          - America/Grand_Turk
+          - America/Grenada
+          - America/Guadeloupe
+          - America/Guatemala
+          - America/Guayaquil
+          - America/Guyana
+          - America/Halifax
+          - America/Havana
+          - America/Hermosillo
+          - America/Indiana/Indianapolis
+          - America/Indiana/Knox
+          - America/Indiana/Marengo
+          - America/Indiana/Petersburg
+          - America/Indiana/Tell_City
+          - America/Indiana/Vevay
+          - America/Indiana/Vincennes
+          - America/Indiana/Winamac
+          - America/Indianapolis
+          - America/Inuvik
+          - America/Iqaluit
+          - America/Jamaica
+          - America/Jujuy
+          - America/Juneau
+          - America/Kentucky/Louisville
+          - America/Kentucky/Monticello
+          - America/Knox_IN
+          - America/Kralendijk
+          - America/La_Paz
+          - America/Lima
+          - America/Los_Angeles
+          - America/Louisville
+          - America/Lower_Princes
+          - America/Maceio
+          - America/Managua
+          - America/Manaus
+          - America/Marigot
+          - America/Martinique
+          - America/Matamoros
+          - America/Mazatlan
+          - America/Mendoza
+          - America/Menominee
+          - America/Merida
+          - America/Metlakatla
+          - America/Mexico_City
+          - America/Miquelon
+          - America/Moncton
+          - America/Monterrey
+          - America/Montevideo
+          - America/Montreal
+          - America/Montserrat
+          - America/Nassau
+          - America/New_York
+          - America/Nipigon
+          - America/Nome
+          - America/Noronha
+          - America/North_Dakota/Beulah
+          - America/North_Dakota/Center
+          - America/North_Dakota/New_Salem
+          - America/Nuuk
+          - America/Ojinaga
+          - America/Panama
+          - America/Pangnirtung
+          - America/Paramaribo
+          - America/Phoenix
+          - America/Port-au-Prince
+          - America/Port_of_Spain
+          - America/Porto_Acre
+          - America/Porto_Velho
+          - America/Puerto_Rico
+          - America/Punta_Arenas
+          - America/Rainy_River
+          - America/Rankin_Inlet
+          - America/Recife
+          - America/Regina
+          - America/Resolute
+          - America/Rio_Branco
+          - America/Rosario
+          - America/Santa_Isabel
+          - America/Santarem
+          - America/Santiago
+          - America/Santo_Domingo
+          - America/Sao_Paulo
+          - America/Scoresbysund
+          - America/Shiprock
+          - America/Sitka
+          - America/St_Barthelemy
+          - America/St_Johns
+          - America/St_Kitts
+          - America/St_Lucia
+          - America/St_Thomas
+          - America/St_Vincent
+          - America/Swift_Current
+          - America/Tegucigalpa
+          - America/Thule
+          - America/Thunder_Bay
+          - America/Tijuana
+          - America/Toronto
+          - America/Tortola
+          - America/Vancouver
+          - America/Virgin
+          - America/Whitehorse
+          - America/Winnipeg
+          - America/Yakutat
+          - America/Yellowknife
+          - Antarctica/Casey
+          - Antarctica/Davis
+          - Antarctica/DumontDUrville
+          - Antarctica/Macquarie
+          - Antarctica/Mawson
+          - Antarctica/McMurdo
+          - Antarctica/Palmer
+          - Antarctica/Rothera
+          - Antarctica/South_Pole
+          - Antarctica/Syowa
+          - Antarctica/Troll
+          - Antarctica/Vostok
+          - Arctic/Longyearbyen
+          - Asia/Aden
+          - Asia/Almaty
+          - Asia/Amman
+          - Asia/Anadyr
+          - Asia/Aqtau
+          - Asia/Aqtobe
+          - Asia/Ashgabat
+          - Asia/Ashkhabad
+          - Asia/Atyrau
+          - Asia/Baghdad
+          - Asia/Bahrain
+          - Asia/Baku
+          - Asia/Bangkok
+          - Asia/Barnaul
+          - Asia/Beirut
+          - Asia/Bishkek
+          - Asia/Brunei
+          - Asia/Calcutta
+          - Asia/Chita
+          - Asia/Choibalsan
+          - Asia/Chongqing
+          - Asia/Chungking
+          - Asia/Colombo
+          - Asia/Dacca
+          - Asia/Damascus
+          - Asia/Dhaka
+          - Asia/Dili
+          - Asia/Dubai
+          - Asia/Dushanbe
+          - Asia/Famagusta
+          - Asia/Gaza
+          - Asia/Harbin
+          - Asia/Hebron
+          - Asia/Ho_Chi_Minh
+          - Asia/Hong_Kong
+          - Asia/Hovd
+          - Asia/Irkutsk
+          - Asia/Istanbul
+          - Asia/Jakarta
+          - Asia/Jayapura
+          - Asia/Jerusalem
+          - Asia/Kabul
+          - Asia/Kamchatka
+          - Asia/Karachi
+          - Asia/Kashgar
+          - Asia/Kathmandu
+          - Asia/Katmandu
+          - Asia/Khandyga
+          - Asia/Kolkata
+          - Asia/Krasnoyarsk
+          - Asia/Kuala_Lumpur
+          - Asia/Kuching
+          - Asia/Kuwait
+          - Asia/Macao
+          - Asia/Macau
+          - Asia/Magadan
+          - Asia/Makassar
+          - Asia/Manila
+          - Asia/Muscat
+          - Asia/Nicosia
+          - Asia/Novokuznetsk
+          - Asia/Novosibirsk
+          - Asia/Omsk
+          - Asia/Oral
+          - Asia/Phnom_Penh
+          - Asia/Pontianak
+          - Asia/Pyongyang
+          - Asia/Qatar
+          - Asia/Qostanay
+          - Asia/Qyzylorda
+          - Asia/Rangoon
+          - Asia/Riyadh
+          - Asia/Saigon
+          - Asia/Sakhalin
+          - Asia/Samarkand
+          - Asia/Seoul
+          - Asia/Shanghai
+          - Asia/Singapore
+          - Asia/Srednekolymsk
+          - Asia/Taipei
+          - Asia/Tashkent
+          - Asia/Tbilisi
+          - Asia/Tehran
+          - Asia/Tel_Aviv
+          - Asia/Thimbu
+          - Asia/Thimphu
+          - Asia/Tokyo
+          - Asia/Tomsk
+          - Asia/Ujung_Pandang
+          - Asia/Ulaanbaatar
+          - Asia/Ulan_Bator
+          - Asia/Urumqi
+          - Asia/Ust-Nera
+          - Asia/Vientiane
+          - Asia/Vladivostok
+          - Asia/Yakutsk
+          - Asia/Yangon
+          - Asia/Yekaterinburg
+          - Asia/Yerevan
+          - Atlantic/Azores
+          - Atlantic/Bermuda
+          - Atlantic/Canary
+          - Atlantic/Cape_Verde
+          - Atlantic/Faeroe
+          - Atlantic/Faroe
+          - Atlantic/Jan_Mayen
+          - Atlantic/Madeira
+          - Atlantic/Reykjavik
+          - Atlantic/South_Georgia
+          - Atlantic/St_Helena
+          - Atlantic/Stanley
+          - Australia/ACT
+          - Australia/Adelaide
+          - Australia/Brisbane
+          - Australia/Broken_Hill
+          - Australia/Canberra
+          - Australia/Currie
+          - Australia/Darwin
+          - Australia/Eucla
+          - Australia/Hobart
+          - Australia/LHI
+          - Australia/Lindeman
+          - Australia/Lord_Howe
+          - Australia/Melbourne
+          - Australia/NSW
+          - Australia/North
+          - Australia/Perth
+          - Australia/Queensland
+          - Australia/South
+          - Australia/Sydney
+          - Australia/Tasmania
+          - Australia/Victoria
+          - Australia/West
+          - Australia/Yancowinna
+          - Brazil/Acre
+          - Brazil/DeNoronha
+          - Brazil/East
+          - Brazil/West
+          - CET
+          - CST6CDT
+          - Canada/Atlantic
+          - Canada/Central
+          - Canada/Eastern
+          - Canada/Mountain
+          - Canada/Newfoundland
+          - Canada/Pacific
+          - Canada/Saskatchewan
+          - Canada/Yukon
+          - Chile/Continental
+          - Chile/EasterIsland
+          - Cuba
+          - EET
+          - EST
+          - EST5EDT
+          - Egypt
+          - Eire
+          - Etc/GMT
+          - Etc/GMT+0
+          - Etc/GMT+1
+          - Etc/GMT+10
+          - Etc/GMT+11
+          - Etc/GMT+12
+          - Etc/GMT+2
+          - Etc/GMT+3
+          - Etc/GMT+4
+          - Etc/GMT+5
+          - Etc/GMT+6
+          - Etc/GMT+7
+          - Etc/GMT+8
+          - Etc/GMT+9
+          - Etc/GMT-0
+          - Etc/GMT-1
+          - Etc/GMT-10
+          - Etc/GMT-11
+          - Etc/GMT-12
+          - Etc/GMT-13
+          - Etc/GMT-14
+          - Etc/GMT-2
+          - Etc/GMT-3
+          - Etc/GMT-4
+          - Etc/GMT-5
+          - Etc/GMT-6
+          - Etc/GMT-7
+          - Etc/GMT-8
+          - Etc/GMT-9
+          - Etc/GMT0
+          - Etc/Greenwich
+          - Etc/UCT
+          - Etc/UTC
+          - Etc/Universal
+          - Etc/Zulu
+          - Europe/Amsterdam
+          - Europe/Andorra
+          - Europe/Astrakhan
+          - Europe/Athens
+          - Europe/Belfast
+          - Europe/Belgrade
+          - Europe/Berlin
+          - Europe/Bratislava
+          - Europe/Brussels
+          - Europe/Bucharest
+          - Europe/Budapest
+          - Europe/Busingen
+          - Europe/Chisinau
+          - Europe/Copenhagen
+          - Europe/Dublin
+          - Europe/Gibraltar
+          - Europe/Guernsey
+          - Europe/Helsinki
+          - Europe/Isle_of_Man
+          - Europe/Istanbul
+          - Europe/Jersey
+          - Europe/Kaliningrad
+          - Europe/Kiev
+          - Europe/Kirov
+          - Europe/Kyiv
+          - Europe/Lisbon
+          - Europe/Ljubljana
+          - Europe/London
+          - Europe/Luxembourg
+          - Europe/Madrid
+          - Europe/Malta
+          - Europe/Mariehamn
+          - Europe/Minsk
+          - Europe/Monaco
+          - Europe/Moscow
+          - Europe/Nicosia
+          - Europe/Oslo
+          - Europe/Paris
+          - Europe/Podgorica
+          - Europe/Prague
+          - Europe/Riga
+          - Europe/Rome
+          - Europe/Samara
+          - Europe/San_Marino
+          - Europe/Sarajevo
+          - Europe/Saratov
+          - Europe/Simferopol
+          - Europe/Skopje
+          - Europe/Sofia
+          - Europe/Stockholm
+          - Europe/Tallinn
+          - Europe/Tirane
+          - Europe/Tiraspol
+          - Europe/Ulyanovsk
+          - Europe/Uzhgorod
+          - Europe/Vaduz
+          - Europe/Vatican
+          - Europe/Vienna
+          - Europe/Vilnius
+          - Europe/Volgograd
+          - Europe/Warsaw
+          - Europe/Zagreb
+          - Europe/Zaporozhye
+          - Europe/Zurich
+          - Factory
+          - GB
+          - GB-Eire
+          - GMT
+          - GMT+0
+          - GMT-0
+          - GMT0
+          - Greenwich
+          - HST
+          - Hongkong
+          - Iceland
+          - Indian/Antananarivo
+          - Indian/Chagos
+          - Indian/Christmas
+          - Indian/Cocos
+          - Indian/Comoro
+          - Indian/Kerguelen
+          - Indian/Mahe
+          - Indian/Maldives
+          - Indian/Mauritius
+          - Indian/Mayotte
+          - Indian/Reunion
+          - Iran
+          - Israel
+          - Jamaica
+          - Japan
+          - Kwajalein
+          - Libya
+          - MET
+          - MST
+          - MST7MDT
+          - Mexico/BajaNorte
+          - Mexico/BajaSur
+          - Mexico/General
+          - NZ
+          - NZ-CHAT
+          - Navajo
+          - PRC
+          - PST8PDT
+          - Pacific/Apia
+          - Pacific/Auckland
+          - Pacific/Bougainville
+          - Pacific/Chatham
+          - Pacific/Chuuk
+          - Pacific/Easter
+          - Pacific/Efate
+          - Pacific/Enderbury
+          - Pacific/Fakaofo
+          - Pacific/Fiji
+          - Pacific/Funafuti
+          - Pacific/Galapagos
+          - Pacific/Gambier
+          - Pacific/Guadalcanal
+          - Pacific/Guam
+          - Pacific/Honolulu
+          - Pacific/Johnston
+          - Pacific/Kanton
+          - Pacific/Kiritimati
+          - Pacific/Kosrae
+          - Pacific/Kwajalein
+          - Pacific/Majuro
+          - Pacific/Marquesas
+          - Pacific/Midway
+          - Pacific/Nauru
+          - Pacific/Niue
+          - Pacific/Norfolk
+          - Pacific/Noumea
+          - Pacific/Pago_Pago
+          - Pacific/Palau
+          - Pacific/Pitcairn
+          - Pacific/Pohnpei
+          - Pacific/Ponape
+          - Pacific/Port_Moresby
+          - Pacific/Rarotonga
+          - Pacific/Saipan
+          - Pacific/Samoa
+          - Pacific/Tahiti
+          - Pacific/Tarawa
+          - Pacific/Tongatapu
+          - Pacific/Truk
+          - Pacific/Wake
+          - Pacific/Wallis
+          - Pacific/Yap
+          - Poland
+          - Portugal
+          - ROC
+          - ROK
+          - Singapore
+          - Turkey
+          - UCT
+          - US/Alaska
+          - US/Aleutian
+          - US/Arizona
+          - US/Central
+          - US/East-Indiana
+          - US/Eastern
+          - US/Hawaii
+          - US/Indiana-Starke
+          - US/Michigan
+          - US/Mountain
+          - US/Pacific
+          - US/Samoa
+          - UTC
+          - Universal
+          - W-SU
+          - WET
+          - Zulu
+          - localtime
+          type: string
+        num_hints_per_submission:
+          description: The number of hints that can be unlocked for this mutation
+            test suite on a single submission. None indicates no limit.
+          nullable: true
+          type: integer
+        obfuscate_mutant_names:
+          description: "Determines whether the mutant names included with\n      \
+            \      unlocked hints should be obfuscated. The options are as follows:\n\
+            \            - \"none\": Do not obfuscate mutant names\n            -\
+            \ \"sequential\": Mutant names are obfuscated as \"Mutant X\",\n     \
+            \       where X is replaced with the index of the mutant in the\n    \
+            \        mutation test suite settings.\n            - \"hash\": Mutant\
+            \ names are obfuscated as \"Mutant X\", where X\n            is replaced\
+            \ with a hash generated using the mutant name and\n            some information\
+            \ unique to the current group. This ensures that\n            obfuscated\
+            \ mutant names are deterministic but unique to the\n            group\
+            \ they are shown to.\n\n        Note that the \"Mutant\" part of \"Mutant\
+            \ X\" in the above examples can\n        be changed in the obfuscated_mutant_name_prefix\
+            \ field."
+          nullable: false
+          enum:
+          - none
+          - sequential
+          - hash
+          type: string
+        obfuscated_mutant_name_prefix:
+          description: "A user-specified prefix for obfuscated mutant names.\n   \
+            \         See \"obfuscated_mutant_names\" for more information."
+          nullable: false
+          type: string
+        created_at:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        last_modified:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+    UnlockedHint:
+      type: object
+      properties:
+        pk:
+          type: integer
+          format: id
+        created_at:
+          description: ''
+          nullable: false
+          type: string
+          format: date-time
+        mutation_test_suite_result:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        mutation_test_suite_hint_config:
+          description: ''
+          nullable: false
+          type: integer
+          format: id
+        mutant_name:
+          description: ''
+          nullable: false
+          type: string
+        hint_number:
+          description: "The index of the unlocked hint in the hint configuration\n\
+            \                     (0-indexed).\n                     Note that if\
+            \ the hints in the list change, the hint this\n                     refers\
+            \ to may be different or no longer exist."
+          nullable: false
+          type: integer
+        hint_text:
+          description: ''
+          nullable: false
+          type: string
+        hint_rating:
+          description: ''
+          nullable: true
+          type: integer
+        user_comment:
+          description: ''
+          nullable: false
+          type: string
+    UserRoles:
+      type: object
+      properties:
+        is_admin:
+          type: boolean
+        is_staff:
+          type: boolean
+        is_student:
+          type: boolean
+        is_handgrader:
+          type: boolean
+    SubmissionWithResults:
+      allOf:
+      - $ref: '#/components/schemas/Submission'
+      - type: object
+        properties:
+          results:
+            $ref: '#/components/schemas/SubmissionResultFeedback'
+  parameters:
+    feedbackCategory:
+      name: feedback_category
+      in: query
+      schema:
+        $ref: '#/components/schemas/FeedbackCategory'
+      description: "The category of feedback being requested. Must be one of the following\n\
+        values:\n\n- normal: Can be requested by\n    students before or after the\
+        \ project deadline on their\n    submissions that did not exceed the daily\
+        \ limit.\n- past_limit_submission: Can be\n    requested by students on their\
+        \ submissions that exceeded the\n    daily limit.\n- ultimate_submission:\
+        \ Can be\n    requested by students on their own ultimate (a.k.a. final\n\
+        \    graded) submission once the project deadline has passed and\n    hide_ultimate_submission_fdbk\
+        \ has been set to False on the\n    project. Can similarly be requested by\
+        \ staff when looking\n    up another user's ultimate submission results after\
+        \ the\n    deadline.\n- staff_viewer: Can be requested\n    by staff when\
+        \ looking up another user's submission results.\n- max: Can be requested by\
+        \ staff\n    on their own submissions."
+    requiredFeedbackCategory:
+      name: feedback_category
+      in: query
+      schema:
+        $ref: '#/components/schemas/FeedbackCategory'
+      description: "The category of feedback being requested. Must be one of the following\n\
+        values:\n\n- normal: Can be requested by\n    students before or after the\
+        \ project deadline on their\n    submissions that did not exceed the daily\
+        \ limit.\n- past_limit_submission: Can be\n    requested by students on their\
+        \ submissions that exceeded the\n    daily limit.\n- ultimate_submission:\
+        \ Can be\n    requested by students on their own ultimate (a.k.a. final\n\
+        \    graded) submission once the project deadline has passed and\n    hide_ultimate_submission_fdbk\
+        \ has been set to False on the\n    project. Can similarly be requested by\
+        \ staff when looking\n    up another user's ultimate submission results after\
+        \ the\n    deadline.\n- staff_viewer: Can be requested\n    by staff when\
+        \ looking up another user's submission results.\n- max: Can be requested by\
+        \ staff\n    on their own submissions."
+    includeStaff:
+      name: include_staff
+      in: query
+      description: When "false", excludes staff and admin users from the results.
+        Defaults to "true".
+      schema:
+        type: string
+        enum:
+        - 'true'
+        - 'false'
+        default: 'true'
+    page:
+      name: page
+      in: query
+      schema:
+        type: integer
+tags:
+- name: users
+- name: courses
+- name: rosters
+- name: projects
+- name: instructor_files
+- name: expected_student_files
+- name: sandbox_docker_images
+- name: ag_test_suites
+- name: ag_test_cases
+- name: ag_test_commands
+- name: mutation_test_suites
+- name: group_invitations
+- name: groups
+- name: submissions
+- name: submission_output
+- name: rerun_submissions_tasks
+- name: handgrading_rubrics
+- name: handgrading_results
+- name: criteria
+- name: annotations
+- name: criterion_results
+- name: applied_annotations
+- name: comments


### PR DESCRIPTION
To facilitate fixing this [bug](https://github.com/eecs-autograder/autograder.io/issues/31) where we needed an efficient way to tell whether a student group's has submitted any non-rejected submissions, we introduced a new field `has_autograded_submissions` in data returned by `ListHandgradingResultsView` Django Rest API. `has_autograded_submissions` is true if the student group has at least one submission on the autograder whose status is `ag_models.Submission.GradingStatus.finished_grading`, and false otherwise, when the student group has no submissions or all their submissions have been rejected.

Previous unit tests have been modified to accommodate this change. New unit tests and interfaces have been written to test student groups who only have rejected submissions. 