### PR TITLE
Add migrate check to lint.sh

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -4,6 +4,7 @@ pycodestyle autograder
 pydocstyle autograder
 ./lint/run_mypy.sh
 python3 manage.py makemigrations --check
+python3 manage.py migrate
 python3 manage.py generateschema --generator_class autograder.rest_api.schema.AGSchemaGenerator > /tmp/schema-check.yml
 diff -q autograder/rest_api/schema/schema.yml /tmp/schema-check.yml
 


### PR DESCRIPTION
Adds a call to ./manage.py migrate to lint.sh to verify that the migrations can actually be applied.