### PR TITLE
Ignore new fields when using deprecated field, ignore deprecated field

### DIFF
--- a/autograder/core/tests/test_utils.py
+++ b/autograder/core/tests/test_utils.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import os
 import tempfile
@@ -12,6 +13,52 @@ import autograder.core.utils as core_ut
 import autograder.utils.testing.model_obj_builders as obj_build
 from autograder.core import constants
 from autograder.utils.testing import UnitTestBase
+
+
+class DateTimesAreEqualTest(UnitTestBase):
+    def test_equal_datetimes(self):
+        now = datetime.datetime.now()
+        now2 = copy.deepcopy(now)
+        self.assertTrue(core_ut.datetimes_are_equal(now, now2))
+        self.assertTrue(core_ut.datetimes_are_equal(now2, now))
+
+    def test_unequal_datetimes(self):
+        now = datetime.datetime.now()
+        later = now + datetime.timedelta(minutes=5)
+        self.assertFalse(core_ut.datetimes_are_equal(now, later))
+        self.assertFalse(core_ut.datetimes_are_equal(later, now))
+
+    def test_equal_strings(self):
+        time1 = '2024-09-12 17:52:05.538324+00:00'
+        time2 = '2024-09-12 17:52:05.538324Z'
+        self.assertTrue(core_ut.datetimes_are_equal(time1, time2))
+        self.assertTrue(core_ut.datetimes_are_equal(time2, time1))
+        self.assertTrue(core_ut.datetimes_are_equal(time1, time1))
+
+    def test_unequal_strings(self):
+        time1 = '2025-09-12 17:52:05.538324+00:00'
+        time2 = '2024-09-12 17:52:05.538324Z'
+        self.assertFalse(core_ut.datetimes_are_equal(time1, time2))
+        self.assertFalse(core_ut.datetimes_are_equal(time2, time1))
+
+    def test_none(self):
+        time1 = None
+        time2 = datetime.datetime.now()
+        self.assertTrue(core_ut.datetimes_are_equal(time1, time1))
+        self.assertFalse(core_ut.datetimes_are_equal(time1, time2))
+        self.assertFalse(core_ut.datetimes_are_equal(time2, time1))
+
+    def test_mixed_equal(self):
+        time1 = datetime.datetime.now()
+        time2 = time1.isoformat()
+        self.assertTrue(core_ut.datetimes_are_equal(time1, time2))
+        self.assertTrue(core_ut.datetimes_are_equal(time2, time1))
+
+    def test_mixed_unequal(self):
+        now = datetime.datetime.now()
+        later = (now + datetime.timedelta(minutes=5)).isoformat()
+        self.assertFalse(core_ut.datetimes_are_equal(now, later))
+        self.assertFalse(core_ut.datetimes_are_equal(later, now))
 
 
 class DiffTestCase(SimpleTestCase):

--- a/autograder/core/tests/test_utils.py
+++ b/autograder/core/tests/test_utils.py
@@ -60,6 +60,16 @@ class DateTimesAreEqualTest(UnitTestBase):
         self.assertFalse(core_ut.datetimes_are_equal(now, later))
         self.assertFalse(core_ut.datetimes_are_equal(later, now))
 
+    def test_invalid_string(self):
+        now = datetime.datetime.now()
+        invalid = "invalid"
+        with self.assertRaises(ValueError):
+            core_ut.datetimes_are_equal(now, invalid)
+        with self.assertRaises(ValueError):
+            core_ut.datetimes_are_equal(invalid, now)
+        with self.assertRaises(ValueError):
+            core_ut.datetimes_are_equal(invalid, invalid)
+
 
 class DiffTestCase(SimpleTestCase):
     def setUp(self):

--- a/autograder/core/utils.py
+++ b/autograder/core/utils.py
@@ -31,25 +31,15 @@ def datetimes_are_equal(datetime1: datetime.datetime | str | None,
 
     :raises: ValueError when either argument is an invalid datetime string.
     """
-    # need to do these checks because parse_datetime returns None when passed
-    # an invalid string.
-    if datetime1 is None and datetime2 is not None:
-        return False
-    elif datetime1 is not None and datetime2 is None:
-        return False
-    elif datetime1 is None and datetime2 is None:
-        return True
-
     if isinstance(datetime1, str):
-        time1_parsed = parse_datetime(datetime1)
-        if time1_parsed is None:
+        datetime1 = parse_datetime(datetime1)
+        if datetime1 is None:
             raise ValueError(f"{datetime1} is not a valid datetime")
-        datetime1 = time1_parsed
+
     if isinstance(datetime2, str):
-        time2_parsed = parse_datetime(datetime2)
-        if time2_parsed is None:
-            raise ValueError(f"{datetime2} is not a valid datetime")
-        datetime2 = time2_parsed
+        datetime2 = parse_datetime(datetime2)
+        if datetime2 is None:
+            raise ValueError(f"{datetime1} is not a valid datetime")
 
     return datetime1 == datetime2
 

--- a/autograder/core/utils.py
+++ b/autograder/core/utils.py
@@ -23,35 +23,35 @@ if typing.TYPE_CHECKING:
     from .models.submission import Submission
 
 
-def datetimes_are_equal(time1: datetime.datetime | str | None,
-                        time2: datetime.datetime | str | None) -> bool:
+def datetimes_are_equal(datetime1: datetime.datetime | str | None,
+                        datetime2: datetime.datetime | str | None) -> bool:
     """
-    Returns true if time1 is equal to time2. Each argument may be either a `datetime.datetime`
-    object, a valid ISO formatted string, or `None`.
+    Returns true if datetime1 is equal to datetime2. Each argument may be either a
+    `datetime.datetime` object, a valid ISO formatted string, or `None`.
 
     :raises: ValueError when either argument is an invalid datetime string.
     """
     # need to do these checks because parse_datetime returns None when passed
     # an invalid string.
-    if time1 is None and time2 is not None:
+    if datetime1 is None and datetime2 is not None:
         return False
-    elif time1 is not None and time2 is None:
+    elif datetime1 is not None and datetime2 is None:
         return False
-    elif time1 is None and time2 is None:
+    elif datetime1 is None and datetime2 is None:
         return True
 
-    if isinstance(time1, str):
-        time1_parsed = parse_datetime(time1)
+    if isinstance(datetime1, str):
+        time1_parsed = parse_datetime(datetime1)
         if time1_parsed is None:
-            raise ValueError(f"{time1} is not a valid time")
-        time1 = time1_parsed
-    if isinstance(time2, str):
-        time2_parsed = parse_datetime(time2)
+            raise ValueError(f"{datetime1} is not a valid datetime")
+        datetime1 = time1_parsed
+    if isinstance(datetime2, str):
+        time2_parsed = parse_datetime(datetime2)
         if time2_parsed is None:
-            raise ValueError(f"{time2} is not a valid time")
-        time2 = time2_parsed
+            raise ValueError(f"{datetime2} is not a valid datetime")
+        datetime2 = time2_parsed
 
-    return time1 == time2
+    return datetime1 == datetime2
 
 
 class InvalidSoftDeadlineError(Exception):

--- a/autograder/core/utils.py
+++ b/autograder/core/utils.py
@@ -12,6 +12,7 @@ import zoneinfo
 from django.conf import settings
 from django.core import exceptions
 from django.utils import timezone
+from django.utils.dateparse import parse_datetime
 
 from . import constants as const
 
@@ -20,6 +21,37 @@ if typing.TYPE_CHECKING:
     from .models.group import Group
     from .models.project import Project
     from .models.submission import Submission
+
+
+def datetimes_are_equal(time1: datetime.datetime | str | None,
+                        time2: datetime.datetime | str | None) -> bool:
+    """
+    Returns true if time1 is equal to time2. Each argument may be either a `datetime.datetime`
+    object, a valid ISO formatted string, or `None`.
+
+    :raises: ValueError when either argument is an invalid datetime string.
+    """
+    # need to do these checks because parse_datetime returns None when passed
+    # an invalid string.
+    if time1 is None and time2 is not None:
+        return False
+    elif time1 is not None and time2 is None:
+        return False
+    elif time1 is None and time2 is None:
+        return True
+
+    if isinstance(time1, str):
+        time1_parsed = parse_datetime(time1)
+        if time1_parsed is None:
+            raise ValueError(f"{time1} is not a valid time")
+        time1 = time1_parsed
+    if isinstance(time2, str):
+        time2_parsed = parse_datetime(time2)
+        if time2_parsed is None:
+            raise ValueError(f"{time2} is not a valid time")
+        time2 = time2_parsed
+
+    return time1 == time2
 
 
 class InvalidSoftDeadlineError(Exception):

--- a/autograder/rest_api/views/group_views.py
+++ b/autograder/rest_api/views/group_views.py
@@ -400,7 +400,6 @@ def clean_extended_due_dates(update_data: Mapping, old_group: ag_models.Group) -
              'hard_extended_due_date', or if any datetime strings in `update_data` are invalid.
     """
     update_data = dict(copy.deepcopy(update_data))
-
     try:
         legacy_changed = 'extended_due_date' in update_data \
             and not core_ut.datetimes_are_equal(update_data['extended_due_date'],


### PR DESCRIPTION
when using new fields.

Return 400 if client tries to change both the deprecated field and one of the new fields.