### PR TITLE
Bump ubuntu 20.04 -> 24.04 for CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -51,7 +51,7 @@ jobs:
           bash lint.sh
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]
@@ -92,7 +92,7 @@ jobs:
           python3 manage.py test -v2 --exclude-tag fix_on_ci --exclude-tag slow --exclude-tag sandbox
 
   slow_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.10"]


### PR DESCRIPTION
20.04 was retired on GitHub runners on 4/15/25