### PR TITLE
Don't raise KeyError on missing docker inspect config fields

### DIFF
--- a/autograder/core/tasks.py
+++ b/autograder/core/tasks.py
@@ -141,8 +141,8 @@ def _validate_image_config(tag: str, task: ag_models.BuildSandboxDockerImageTask
     config = json.loads(inspect_result.stdout)
 
     error_msg = ''
-    entrypoint = config['Entrypoint']
-    cmd = config['Cmd']
+    entrypoint = config.get('Entrypoint')
+    cmd = config.get('Cmd')
     if entrypoint is not None:
         error_msg += 'Custom images may not use the ENTRYPOINT directive.\n'
 


### PR DESCRIPTION
See https://github.com/moby/moby/pull/50135

Some versions of Docker currently will omit null fields from `docker inspect`, and it is planned to omit them in future versions as well. This change avoids `KeyError`'s when `Entrypoint` or `Cmd` are missing from the config object