### PR TITLE
Fix CI create-release version bumping.

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -177,18 +177,34 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
 
     steps:
-      - uses: actions/checkout@v3
+      # See https://github.com/organizations/eecs-autograder/settings/apps
+      # and https://github.com/orgs/community/discussions/25305#discussioncomment-8256560
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.VERSION_BUMPER_APPID }}
+          private-key: ${{ secrets.VERSION_BUMPER_SECRET }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      - run: |
+          git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       # Yes, we're running this on each step because I couldn't figure out
       # the quirks of uploading/downloading artifacts into the right
       # directory
       - name: Update version number (on dispatch only)
         run: ./dev_scripts/ci/update_version_number.sh "${{ inputs.version }}"
-
-      - name: Set up Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Commit updated version files
         run: |


### PR DESCRIPTION
Use custom app with bypass permission and app token to make pushing a version commit and tag work.